### PR TITLE
Feature/initial implementation

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,86 @@
+name: Windows Build and Release
+
+on:
+  # Manually triggered from GitHub UI
+  workflow_dispatch:
+  
+  # On release tag push
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    name: Build Windows Binary
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+          
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        
+      - name: Build
+        run: cargo build --release
+        
+      - name: Test
+        run: cargo test
+      
+      - name: Create dist directory
+        run: mkdir -p dist
+      
+      - name: Package binaries
+        run: |
+          copy target\release\mtr.exe dist\windows-mtr.exe
+          
+          # Create the ZIP package
+          cd dist
+          
+          # Use PowerShell to create a ZIP file
+          powershell -command "Compress-Archive -Path 'windows-mtr.exe' -DestinationPath 'windows-mtr.zip' -Force"
+          
+          # Also create a copy with the original name for convenience
+          copy windows-mtr.exe mtr.exe
+          powershell -command "Compress-Archive -Path 'mtr.exe', 'windows-mtr.exe', '..\README.md', '..\LICENSE', '..\USAGE.md' -DestinationPath 'windows-mtr-full.zip' -Force"
+          
+          # Generate SHA-256 checksums
+          powershell -command "$files = Get-ChildItem -Filter '*.zip'; foreach ($file in $files) { $hash = Get-FileHash -Path $file.FullName -Algorithm SHA256; Add-Content -Path 'SHA256SUMS' -Value `"$($hash.Hash)  $($file.Name)`" }"
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-binaries
+          path: |
+            dist/windows-mtr.exe
+            dist/mtr.exe
+            dist/*.zip
+            dist/SHA256SUMS
+          
+  # Only run on tag push
+  release:
+    needs: build-windows
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        
+      - name: Display structure of downloaded files
+        run: ls -R
+        
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            windows-binaries/windows-mtr.exe
+            windows-binaries/*.zip
+            windows-binaries/SHA256SUMS
+          draft: true
+          generate_release_notes: true

--- a/build.rs
+++ b/build.rs
@@ -3,12 +3,18 @@ fn main() {
     #[cfg(windows)]
     {
         println!("cargo:rustc-link-arg=/SUBSYSTEM:CONSOLE");
+    }
         
-        // Windows cross-compilation support when building on non-windows
-        if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
-            // Ensure we can find windows libraries when cross-compiling
-            println!("cargo:rustc-link-lib=iphlpapi");
-            println!("cargo:rustc-link-lib=ws2_32");
+    // Windows cross-compilation support
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() == "windows" {
+        // Ensure we can find windows libraries when cross-compiling
+        println!("cargo:rustc-link-lib=iphlpapi");
+        println!("cargo:rustc-link-lib=ws2_32");
+        
+        // When cross-compiling, explicitly set MSVC environment
+        if cfg!(not(windows)) {
+            println!("cargo:warning=Cross-compiling Windows binary from non-Windows environment");
+            println!("cargo:rustc-link-search=native=xwin-dlls");
         }
     }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,3 +11,5 @@ sha2 = "0.10.8"
 hex = "0.4.3"
 walkdir = "2.4.0"
 xz2 = "0.1.7"  # XZ compression for smaller package size
+cargo_metadata = "0.15.4"  # For accessing cargo metadata
+dunce = "1.0.4"  # For normalizing paths

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,17 +8,33 @@ use std::process::Command;
 use walkdir::WalkDir;
 use xz2::write::XzEncoder;
 use zip::write::{FileOptions, ZipWriter};
+use cargo_metadata::{MetadataCommand, Package};
 
 fn main() -> Result<()> {
     let task = env::args().nth(1);
     match task.as_deref() {
         Some("dist") => dist()?,
+        Some("dist-windows") => dist_windows()?,
+        Some("test-windows") => test_windows()?,
+        Some("package-win") => package_win_manually()?,
         _ => {
             println!("Available tasks:");
             println!("  dist - Build release binaries and package for distribution");
+            println!("  dist-windows - Cross-compile and package Windows binaries");
+            println!("  test-windows - Test Windows binaries using Docker");
+            println!("  package-win - Create Windows package from existing binary");
         }
     }
     Ok(())
+}
+
+fn get_package_metadata() -> Result<Package> {
+    let metadata = MetadataCommand::new().exec()?;
+    let package = metadata.root_package()
+        .context("Failed to find root package")?
+        .clone();
+    
+    Ok(package)
 }
 
 fn dist() -> Result<()> {
@@ -61,6 +77,235 @@ fn dist() -> Result<()> {
     println!("Distribution packages created successfully in: {:?}", dist_dir);
     println!("Regular ZIP: {:?}", zip_path);
     println!("XZ compressed: {:?} (approximately 40% smaller)", xz_path);
+    
+    Ok(())
+}
+
+fn dist_windows() -> Result<()> {
+    println!("Cross-compiling Windows binaries...");
+
+    // Install the cross-compilation target if needed
+    let target = "x86_64-pc-windows-msvc";
+    let status = Command::new("rustup")
+        .args(["target", "add", target])
+        .status()
+        .context("Failed to add Windows target")?;
+
+    if !status.success() {
+        anyhow::bail!("Failed to add Windows target");
+    }
+
+    // Check if cargo-xwin is installed
+    let mut xwin_exists = Command::new("cargo")
+        .args(["xwin", "--version"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+
+    // If not installed, install it
+    if !xwin_exists {
+        println!("Installing cargo-xwin...");
+        let status = Command::new("cargo")
+            .args(["install", "cargo-xwin"])
+            .status()
+            .context("Failed to install cargo-xwin")?;
+
+        if !status.success() {
+            anyhow::bail!("Failed to install cargo-xwin");
+        }
+        xwin_exists = true;
+    }
+
+    // Build for Windows using cargo-xwin (or use cargo directly with target flag)
+    let build_status = if xwin_exists {
+        Command::new("cargo")
+            .args(["xwin", "build", "--release"])
+            .status()
+            .context("Failed to run cargo xwin build")?
+    } else {
+        Command::new("cargo")
+            .args(["build", "--release", "--target", target])
+            .status()
+            .context("Failed to cross-compile with cargo")?
+    };
+
+    if !build_status.success() {
+        anyhow::bail!("Windows build failed");
+    }
+
+    // Create dist directory if it doesn't exist
+    let dist_dir = PathBuf::from("dist");
+    fs::create_dir_all(&dist_dir).context("Failed to create dist directory")?;
+
+    // Paths to binaries - now under target/x86_64-pc-windows-msvc/release
+    let release_dir = PathBuf::from(format!("target/{}/release", target));
+    let source_binary = release_dir.join("mtr.exe");
+
+    // Create a standard ZIP archive
+    let zip_path = dist_dir.join("windows-mtr.zip");
+    println!("Creating ZIP archive: {:?}", zip_path);
+    create_zip_archive(&source_binary, &zip_path)?;
+    
+    // Create an XZ compressed ZIP for smaller size
+    let xz_path = dist_dir.join("windows-mtr.zip.xz");
+    println!("Creating XZ compressed archive: {:?}", xz_path);
+    create_xz_archive(&zip_path, &xz_path)?;
+    
+    // Generate SHA256 checksums
+    generate_checksums(&dist_dir)?;
+
+    println!("Windows distribution packages created successfully in: {:?}", dist_dir);
+    println!("Regular ZIP: {:?}", zip_path);
+    println!("XZ compressed: {:?} (approximately 40% smaller)", xz_path);
+    
+    Ok(())
+}
+
+fn test_windows() -> Result<()> {
+    println!("Testing Windows executable using Docker...");
+    
+    // Check if we have Windows executable
+    let windows_exe = "dist/windows-mtr.exe";
+    if !Path::new(windows_exe).exists() {
+        println!("Windows executable not found. Building it first...");
+        dist_windows()?;
+    }
+    
+    // Prepare a temporary directory for Windows testing
+    let test_dir = PathBuf::from("target/windows-test");
+    fs::create_dir_all(&test_dir).context("Failed to create test directory")?;
+    
+    // Copy the executable and test files
+    fs::copy("dist/windows-mtr.exe", test_dir.join("mtr.exe"))
+        .context("Failed to copy Windows executable")?;
+    
+    // Create a simple batch test script
+    let test_script = r#"@echo off
+echo Running Windows MTR tests...
+echo.
+echo Testing help command:
+mtr.exe --help > help_output.txt
+echo 1. Help command test: %ERRORLEVEL%
+echo.
+
+echo Testing version command:
+mtr.exe --version > version_output.txt  
+echo 2. Version command test: %ERRORLEVEL%
+echo.
+
+rem A simple test that doesn't need network access
+echo Testing argument parsing:
+mtr.exe -T -P 443 -c 1 -r --help > args_output.txt
+echo 3. Argument parsing test: %ERRORLEVEL%
+echo.
+
+echo All tests completed!
+"#;
+    
+    fs::write(test_dir.join("test.bat"), test_script)
+        .context("Failed to create test script")?;
+    
+    // Create Dockerfile for Windows container
+    let dockerfile = r#"FROM mcr.microsoft.com/windows/servercore:ltsc2022
+WORKDIR C:\\app
+COPY . .
+CMD ["cmd", "/c", "test.bat"]
+"#;
+    
+    fs::write(test_dir.join("Dockerfile"), dockerfile)
+        .context("Failed to create Dockerfile")?;
+    
+    // Check if Docker is installed
+    let docker_status = Command::new("docker")
+        .args(["--version"])
+        .status();
+    
+    if docker_status.is_err() || !docker_status.unwrap().success() {
+        println!("Docker not found or not running. Please install Docker to test Windows binaries.");
+        println!("Alternatively, you can manually test the Windows binary on a Windows machine.");
+        println!("Test files prepared in: {:?}", test_dir);
+        return Ok(());
+    }
+    
+    // Build and run Windows container (requires Windows containers enabled in Docker)
+    println!("Building Windows test container...");
+    println!("Note: This requires Docker with Windows containers support.");
+    println!("If you're on Linux, this will likely fail unless you have special configuration.");
+    
+    let build_cmd = Command::new("docker")
+        .current_dir(&test_dir)
+        .args(["build", "-t", "windows-mtr-test", "."])
+        .status()
+        .context("Failed to build Docker container")?;
+    
+    if !build_cmd.success() {
+        println!("Failed to build Windows container.");
+        println!("This is expected on Linux without specialized Docker configuration.");
+        println!("Alternative: Test the Windows binary directly on a Windows machine.");
+        println!("Test files prepared in: {:?}", test_dir);
+        return Ok(());
+    }
+    
+    println!("Running tests in Windows container...");
+    let run_cmd = Command::new("docker")
+        .args(["run", "--rm", "windows-mtr-test"])
+        .status()
+        .context("Failed to run Docker container")?;
+    
+    if !run_cmd.success() {
+        anyhow::bail!("Windows tests failed");
+    }
+    
+    println!("Windows tests completed successfully!");
+    Ok(())
+}
+
+fn package_win_manually() -> Result<()> {
+    println!("Creating Windows package manually...");
+    
+    // Create dist directory if it doesn't exist
+    let dist_dir = PathBuf::from("dist");
+    fs::create_dir_all(&dist_dir).context("Failed to create dist directory")?;
+    
+    // Create a dummy Windows executable if not cross-compiling
+    let dummy_exe = dist_dir.join("mtr.exe");
+    if !dummy_exe.exists() {
+        println!("Creating placeholder Windows executable...");
+        let mut file = File::create(&dummy_exe)
+            .context("Failed to create dummy Windows executable")?;
+        
+        // Write a minimal PE header to make it a valid Windows executable
+        // This is just for packaging demonstration - it won't run
+        let pe_header = b"MZ\x90\x00\x03\x00\x00\x00\x04\x00\x00\x00\xFF\xFF\x00\x00\
+                         \xB8\x00\x00\x00\x00\x00\x00\x00\x40\x00\x00\x00\x00\x00\x00\x00\
+                         \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+                         \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\
+                         \x0E\x1F\xBA\x0E\x00\xB4\x09\xCD\x21\xB8\x01\x4C\xCD\x21\x54\x68\
+                         \x69\x73\x20\x70\x72\x6F\x67\x72\x61\x6D\x20\x63\x61\x6E\x6E\x6F\
+                         \x74\x20\x62\x65\x20\x72\x75\x6E\x20\x69\x6E\x20\x44\x4F\x53\x20\
+                         \x6D\x6F\x64\x65\x2E\x0D\x0D\x0A\x24\x00\x00\x00\x00\x00\x00\x00";
+        
+        file.write_all(pe_header)?;
+        println!("Created placeholder Windows executable at: {}", dummy_exe.display());
+    }
+
+    // Create a standard ZIP archive
+    let zip_path = dist_dir.join("windows-mtr.zip");
+    println!("Creating ZIP archive: {:?}", zip_path);
+    create_zip_archive(&dummy_exe, &zip_path)?;
+    
+    // Create an XZ compressed ZIP for smaller size
+    let xz_path = dist_dir.join("windows-mtr.zip.xz");
+    println!("Creating XZ compressed archive: {:?}", xz_path);
+    create_xz_archive(&zip_path, &xz_path)?;
+    
+    // Generate SHA256 checksums
+    generate_checksums(&dist_dir)?;
+
+    println!("Windows packaging completed!");
+    println!("Note: This is a demonstration package with a placeholder executable.");
+    println!("For a real Windows binary, you would need to build on a Windows machine or");
+    println!("configure a proper cross-compilation environment.");
     
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces comprehensive support for building, testing, and packaging Windows binaries for the project. Key changes include the addition of a GitHub Actions workflow for Windows builds, enhancements to cross-compilation support, and several new tasks in the `xtask` utility for managing Windows-specific operations. Below are the most important changes grouped by theme:

### Windows Build and Release Workflow
* Added a new GitHub Actions workflow (`.github/workflows/windows-build.yml`) to automate building, testing, and packaging Windows binaries, including SHA-256 checksum generation and artifact uploads. The workflow triggers on manual dispatch or release tag pushes.

### Cross-Compilation Enhancements
* Updated `build.rs` to improve cross-compilation support by ensuring Windows libraries are linked and adding a warning when cross-compiling from non-Windows environments. Explicitly set MSVC environment when cross-compiling.

### `xtask` Utility Enhancements
* Added dependencies `cargo_metadata` and `dunce` to `xtask/Cargo.toml` for accessing Cargo metadata and normalizing paths.
* Introduced new tasks in `xtask/src/main.rs`:
  - `dist-windows`: Cross-compiles and packages Windows binaries.
  - `test-windows`: Tests Windows binaries using Docker.
  - [`package-win`](diffhunk://#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35R11-R39): Manually creates a Windows package with placeholder executables. [[1]](diffhunk://#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35R11-R39) [[2]](diffhunk://#diff-9c5e61698d6d8a8ef4a3da7075c31857769134a932ac141d4eb62f68f131aa35R84-R349)

### Packaging and Testing Improvements
* Added helper functions in `xtask/src/main.rs` to create placeholder Windows executables, ZIP archives, and XZ-compressed packages. Also included functionality to generate SHA-256 checksums for distribution files.