### PR TITLE
docs: add AGENTS.md and AI_INSTRUCTIONS.md

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,16 @@
+# GitHub Agents Guidance
+
+This directory contains role-specific guidance for automated or semi-automated agents used in CI/CD and repository maintenance.
+
+## Current files
+- `maintainer-agent.md`: baseline guidance for repo-aware maintenance tasks.
+
+## Usage model
+- Keep agent scopes narrow and explicit.
+- Prefer read-only analysis agents for triage/reporting tasks.
+- Require explicit tests/checks for any code-writing agent.
+- Avoid overlapping ownership between agent specs.
+
+## Change management
+- Update this directory when introducing a new automation role.
+- Document trigger conditions, allowed actions, and output expectations.

--- a/.github/agents/maintainer-agent.md
+++ b/.github/agents/maintainer-agent.md
@@ -1,0 +1,34 @@
+# Maintainer Agent Specification
+
+## Purpose
+Perform small, high-confidence maintenance updates in `windows-mtr`.
+
+## Allowed tasks
+- Documentation improvements.
+- Test additions/adjustments aligned to existing behavior.
+- Small bug fixes with targeted scope.
+
+## Prohibited tasks (unless explicitly requested)
+- Broad architecture rewrites.
+- Dependency churn without clear justification.
+- Silent behavior changes to CLI defaults.
+
+## Required process
+1. Inspect relevant source and tests first.
+2. Implement the smallest safe change.
+3. Run validation checks when possible.
+4. Summarize exact impacts and risks.
+
+## Validation commands
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+## Output contract
+Every update must include:
+- Files changed.
+- Rationale.
+- Exact validation commands and outcomes.
+- Any environment limitations.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,43 @@
+# Copilot Instructions for `windows-mtr`
+
+These instructions guide GitHub Copilot and AI code assistants when proposing changes in this repository.
+
+## Project intent
+- Maintain a reliable, secure Windows-oriented MTR experience.
+- Keep CLI behavior stable unless the change explicitly documents compatibility impact.
+- Favor focused changes over broad refactors.
+
+## Engineering expectations
+- Follow patterns already used in nearby Rust modules.
+- Prefer explicit, typed error paths and clear user-facing messages.
+- Treat hostnames, packet data, and CLI input as untrusted.
+- Avoid adding dependencies unless there is a strong, documented reason.
+
+## Required checks before suggesting completion
+Run what is available in the environment:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+If a check cannot run, state the exact blocker and do not fabricate results.
+
+## Documentation discipline
+Update docs when changing:
+- CLI flags/options/defaults.
+- Output/report format.
+- Build or installation flow.
+
+Primary docs:
+- `README.md`
+- `USAGE.md`
+- `CHANGELOG.md` (when user-facing behavior changes)
+
+## Pull request quality
+PR descriptions should include:
+1. What changed.
+2. Why it changed.
+3. How it was validated (exact commands).
+4. Risks and compatibility notes.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "**/*.md"
+---
+# Documentation instructions for windows-mtr
+
+- Keep docs actionable and task-oriented.
+- When user-facing behavior changes, update `README.md`, `USAGE.md`, and `CHANGELOG.md` as needed.
+- Prefer stable headings and short sections to keep Copilot context efficient.
+- Do not claim tests/checks were executed unless command output confirms it.

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "src/**/*.rs,tests/**/*.rs,examples/**/*.rs,xtask/**/*.rs"
+---
+# Rust code generation instructions for windows-mtr
+
+- Preserve CLI compatibility unless explicitly requested.
+- Follow existing error handling patterns and avoid silent fallbacks.
+- Add or adjust tests for behavior changes.
+- Prefer minimal diffs; avoid broad refactors unrelated to the task.
+- Validate with:
+  - `cargo fmt --all -- --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test --all`
+- If checks cannot run, state the exact environment blocker and stop short of fabrication.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+This file provides instructions for autonomous coding agents working in this repository.
+
+## 1) Mission and contribution goals
+- Keep `windows-mtr` reliable, secure, and predictable for networking diagnostics.
+- Prefer small, reviewable pull requests with clear user impact.
+- Preserve CLI compatibility unless change is explicitly documented.
+
+## 2) Required workflow for every change
+1. **Understand context first**
+   - Read `README.md`, `USAGE.md`, and relevant source/tests before editing.
+2. **Plan before editing**
+   - Identify affected modules, risks, and validation steps.
+3. **Implement minimal safe change**
+   - Avoid broad refactors unless required by the task.
+4. **Validate locally**
+   - Run formatting, linting, and tests relevant to touched code.
+5. **Document and summarize**
+   - Update docs/changelog when behavior or UX changes.
+
+## 3) Repository map
+- `src/` — application source.
+- `tests/` — integration/unit/report tests and fixtures.
+- `examples/` — sample usage.
+- `xtask/` — project automation helpers.
+- `README.md` and `USAGE.md` — user documentation and commands.
+
+## 4) Coding standards
+- Follow existing Rust style and naming patterns in nearby files.
+- Prioritize correctness and explicit error handling over cleverness.
+- Do not introduce silent fallbacks for network errors without justification.
+- Keep functions cohesive and avoid unnecessary public surface expansion.
+- Add or update tests for bug fixes and behavior changes.
+
+## 5) Testing and quality gates
+When available, prefer running these commands before finalizing:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+If a command is not runnable in the environment, report exactly why.
+
+## 6) Security and safety rules
+- Treat all external inputs (CLI args, hostnames, packets, files) as untrusted.
+- Avoid logging sensitive data or unnecessary host-identifying details.
+- Do not add telemetry, network beacons, or data exfiltration behavior.
+- Keep dependencies minimal; justify and document any new dependency.
+
+## 7) Performance guidelines
+- Be mindful of hot paths in probe/report loops.
+- Avoid needless allocations and blocking operations in frequently executed paths.
+- Include a short performance note in PRs for non-trivial algorithmic changes.
+
+## 8) Documentation expectations
+Update docs when any of these change:
+- CLI flags/options/defaults.
+- Output formats or report fields.
+- Installation/build/run instructions.
+
+## 9) Commit and PR guidance
+- Use imperative, specific commit messages.
+- PR descriptions should include:
+  - What changed.
+  - Why it changed.
+  - How it was tested.
+  - Any compatibility or risk notes.
+
+## 10) Non-goals and restrictions
+- Do not rewrite large modules unless explicitly requested.
+- Do not change license or legal notices without maintainer instruction.
+- Do not commit generated artifacts unless repository convention requires it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,9 +77,11 @@ Update docs when any of these change:
 ## 11) GitHub automation files
 - Keep Copilot guidance in `.github/copilot-instructions.md`.
 - Keep role-specific agent specs in `.github/agents/`.
+- Keep path-specific Copilot rules in `.github/instructions/*.instructions.md` using `applyTo`.
 - Ensure agent specs define scope, prohibited actions, validation, and output contract.
 
 ## 12) Repository-local skills
 - Place project-specific skills under `skills/<skill-name>/SKILL.md`.
+- Keep skill metadata concise and trigger-oriented; move long details into `references/`.
 - Prefer narrow skills that automate repeatable tasks (diagnostics, release prep, docs sync).
 - Reuse scripts/templates from a skill directory instead of duplicating long instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,13 @@ Update docs when any of these change:
 - Do not rewrite large modules unless explicitly requested.
 - Do not change license or legal notices without maintainer instruction.
 - Do not commit generated artifacts unless repository convention requires it.
+
+## 11) GitHub automation files
+- Keep Copilot guidance in `.github/copilot-instructions.md`.
+- Keep role-specific agent specs in `.github/agents/`.
+- Ensure agent specs define scope, prohibited actions, validation, and output contract.
+
+## 12) Repository-local skills
+- Place project-specific skills under `skills/<skill-name>/SKILL.md`.
+- Prefer narrow skills that automate repeatable tasks (diagnostics, release prep, docs sync).
+- Reuse scripts/templates from a skill directory instead of duplicating long instructions.

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -57,3 +57,11 @@ A strong AI-authored PR should include:
 
 ## Ownership and review
 AI output is draft quality until reviewed by a human maintainer. Reviewers may request simplification, stronger tests, or tighter scope.
+
+## GitHub-native instruction files
+When applicable, keep these aligned:
+- `.github/copilot-instructions.md` for Copilot behavior.
+- `.github/agents/` for role-based agent specifications.
+- Root `AGENTS.md` for repository-wide agent policy.
+
+If rules overlap, repository-wide policy should remain consistent across all files.

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -1,0 +1,59 @@
+# AI Instructions for Contributors and Automated Agents
+
+This document defines best-practice standards for AI-assisted changes in `windows-mtr`.
+
+## Purpose
+Use AI to improve developer productivity **without reducing** code quality, security, or maintainability.
+
+## Core principles
+1. **Human intent first**: Align changes to the requested outcome; avoid speculative edits.
+2. **Smallest effective change**: Minimize diff size while fully solving the task.
+3. **Verifiable output**: Every behavioral change should be validated by tests or reproducible checks.
+4. **Traceability**: Summaries must explain what changed and why.
+5. **Safety by default**: Preserve secure defaults and robust error handling.
+
+## What AI agents should always do
+- Inspect relevant code and tests before editing.
+- Reuse existing patterns from nearby modules.
+- Add/adjust tests when behavior changes.
+- Keep user-facing docs synchronized with code changes.
+- Call out assumptions and environment limitations explicitly.
+
+## What AI agents must avoid
+- Fabricating test results or command outcomes.
+- Introducing hidden behavior, telemetry, or tracking.
+- Making unrelated opportunistic refactors in task-focused PRs.
+- Weakening validation, linting, or security checks to “make CI pass.”
+
+## Recommended validation checklist
+Run what is feasible for the scope:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+For docs-only changes, at minimum verify formatting and markdown rendering quality.
+
+## Change classification rubric
+- **Docs-only**: No runtime behavior changed. Prefer no-code diff.
+- **Bug fix**: Add regression coverage when practical.
+- **Feature**: Include tests + docs + backward compatibility notes.
+- **Refactor**: Must be behavior-preserving with test evidence.
+
+## PR quality bar for AI-authored changes
+A strong AI-authored PR should include:
+- Concise problem statement.
+- Focused solution summary.
+- Risks/tradeoffs.
+- Exact commands run for validation.
+- Follow-up work (if any) separated from current scope.
+
+## Suggested commit message format
+- `docs: add AI and agent contribution guidance`
+- `fix: handle <specific error path> in <module>`
+- `feat: add <capability> for <use case>`
+
+## Ownership and review
+AI output is draft quality until reviewed by a human maintainer. Reviewers may request simplification, stronger tests, or tighter scope.

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -62,6 +62,7 @@ AI output is draft quality until reviewed by a human maintainer. Reviewers may r
 When applicable, keep these aligned:
 - `.github/copilot-instructions.md` for Copilot behavior.
 - `.github/agents/` for role-based agent specifications.
+- `.github/instructions/*.instructions.md` for path-scoped Copilot rules.
 - Root `AGENTS.md` for repository-wide agent policy.
 
 If rules overlap, repository-wide policy should remain consistent across all files.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,39 @@
+# Local Skills (Repository Scaffold)
+
+This folder is reserved for project-specific skills used by autonomous agents.
+
+## Why this exists
+- Keep repeatable, domain-specific workflows close to the codebase.
+- Standardize how agents perform diagnostics, docs updates, and release chores.
+
+## Suggested structure
+- `skills/<skill-name>/SKILL.md` — required entrypoint.
+- `skills/<skill-name>/references/` — concise reference docs.
+- `skills/<skill-name>/scripts/` — helper scripts invoked by skill steps.
+- `skills/<skill-name>/assets/` — reusable templates/checklists.
+
+## Minimal `SKILL.md` template
+```md
+# <skill-name>
+
+## Use when
+Describe the trigger conditions.
+
+## Inputs
+List required context/parameters.
+
+## Steps
+1. ...
+2. ...
+
+## Validation
+Commands/checks to run.
+
+## Output
+Expected artifacts and summary format.
+```
+
+## Notes
+- Keep skills narrowly scoped.
+- Avoid embedding large, duplicated docs; link to canonical files.
+- Prefer scripts for repeatable procedures.

--- a/skills/repo-maintenance/SKILL.md
+++ b/skills/repo-maintenance/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: repo-maintenance
+description: Use this skill when making routine maintenance changes in this repository, including docs updates, small bug fixes, and test-safe refactors that must follow repository guardrails and validation steps.
+---
+
+# repo-maintenance
+
+## Use when
+- The task is a focused repository update (docs, minor fixes, localized improvements).
+- You need predictable process and validation requirements for this repo.
+
+## Inputs
+- User request.
+- Files likely impacted.
+- Current CI/toolchain constraints.
+
+## Steps
+1. Read root `AGENTS.md`, `README.md`, and relevant touched files.
+2. Plan a smallest-safe diff and avoid unrelated cleanup.
+3. Implement changes using existing local patterns.
+4. Validate with repo checks when possible.
+5. Summarize exact commands run, results, and limitations.
+
+## Validation
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+## References
+- For repository policy and precedence details, read `references/instruction-precedence.md`.
+
+## Output
+- Concise change summary.
+- File list and rationale.
+- Exact validation command outcomes.

--- a/skills/repo-maintenance/references/instruction-precedence.md
+++ b/skills/repo-maintenance/references/instruction-precedence.md
@@ -1,0 +1,25 @@
+# Instruction precedence and structure (research summary)
+
+This reference captures practical structure guidance based on GitHub Copilot custom-instruction docs and agent-instruction patterns.
+
+## Recommended layering
+1. `.github/copilot-instructions.md`
+   - Repository-wide Copilot guidance.
+2. `.github/instructions/*.instructions.md`
+   - Path-scoped, `applyTo`-based instructions for language or area-specific rules.
+3. `AGENTS.md` files
+   - Agent-specific operational policy; nearest file in tree takes precedence.
+4. `skills/<name>/SKILL.md`
+   - Repeatable, domain-specific workflows for autonomous agents.
+
+## Practical implications
+- Keep repository-wide files short and durable.
+- Put fast-changing, path-specific rules in `.github/instructions` files.
+- Avoid duplicating long policy text across all instruction surfaces.
+- Keep explicit validation commands in all layers where code generation occurs.
+
+## External references used
+- GitHub Docs: *Adding repository custom instructions for GitHub Copilot* (describes repository-wide, path-specific, and agent instruction types).
+- GitHub Docs: *Support for different types of custom instructions* (feature support matrix).
+- GitHub Docs reusable guidance: *Writing effective custom instructions* (keep instructions concise and broadly applicable).
+- OpenAI `agents.md` convention linked from GitHub docs.


### PR DESCRIPTION
### Motivation
- Provide repository-scoped guidance for autonomous agents and AI-assisted contributors to ensure changes are small, reviewable, secure, and properly validated.

### Description
- Add two documentation files: `AGENTS.md` with operating workflow, coding standards, testing/quality gates, security rules, and PR guidance, and `AI_INSTRUCTIONS.md` with best-practice principles, validation checklist, change-class rubric, and PR quality bar for AI-assisted changes.

### Testing
- Attempted to run the project test suite with `cargo test --all --quiet`, which failed in this environment due to a Rust toolchain mismatch (`rustc 1.87.0` installed while the project and some dependencies require `1.88.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a38dd37cc833098d345f9bca5cfed)