### PR TITLE
Fix report/json count failures and quoted --trippy-flags passthrough

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,9 +176,21 @@ fn duration_seconds(value: f32) -> String {
 }
 
 fn parse_passthrough_flags(flags: &str) -> Result<Vec<String>> {
-    shlex::split(flags).ok_or_else(|| {
+    let parsed = shlex::split(flags).ok_or_else(|| {
         MtrError::InvalidOption("--trippy-flags contains invalid shell quoting".to_string())
-    })
+    })?;
+
+    // Windows shells sometimes preserve wrapping quotes around the entire passthrough
+    // string, which can produce a single token like "--flag value". Split that token
+    // into distinct args so trippy receives valid argv entries.
+    if parsed.len() == 1 {
+        let token = &parsed[0];
+        if token.starts_with("--") && token.contains(' ') {
+            return Ok(token.split_whitespace().map(ToString::to_string).collect());
+        }
+    }
+
+    Ok(parsed)
 }
 
 fn build_embedded_trippy_args(args: &Cli, host: &str) -> Result<Vec<String>> {
@@ -202,7 +214,6 @@ fn build_embedded_trippy_args(args: &Cli, host: &str) -> Result<Vec<String>> {
 
     if let Some(count) = args.count {
         trippy_args.extend(["--report-cycles".to_string(), count.to_string()]);
-        trippy_args.extend(["--max-rounds".to_string(), count.to_string()]);
     }
 
     if let Some(interval) = args.interval {
@@ -398,6 +409,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_passthrough_flags_splits_single_quoted_token() {
+        let parsed =
+            parse_passthrough_flags("\"--tui-refresh-rate 150ms\"").expect("flags should parse");
+        assert_eq!(parsed, vec!["--tui-refresh-rate", "150ms"]);
+    }
+
+    #[test]
     fn build_embedded_trippy_args_maps_core_flags() {
         let args = Cli {
             host: "example.com".to_string(),
@@ -438,8 +456,6 @@ mod tests {
                 "--source-port",
                 "50000",
                 "--report-cycles",
-                "10",
-                "--max-rounds",
                 "10",
                 "--min-round-duration",
                 "0.5s",


### PR DESCRIPTION
### Motivation
- Trippy CLI now rejects `--max-rounds` which caused `-c/--count` to fail in report/json flows, and some Windows shells preserve outer quotes for passthrough flags producing an invalid single token for `--trippy-flags`.

### Description
- Stop forwarding `--max-rounds` when `-c/--count` is used and only forward `--report-cycles` to match current trippy expectations. 
- Improve `parse_passthrough_flags` to detect a single quoted token like `"--tui-refresh-rate 150ms"` and split it into separate argv entries before returning. 
- Add a unit test covering the single-quoted passthrough token case and update an existing test expectation to reflect the removal of `--max-rounds`. 
- All changes are contained in `src/main.rs` and keep the public CLI surface unchanged.

### Testing
- Ran `cargo fmt --all` which succeeded and ensured code is formatted.
- Attempted `cargo clippy --all-targets --all-features -- -D warnings` but it could not complete because the local Rust toolchain is `1.87.0` while the project requires `1.88.0`.
- Attempted `cargo test --all` but it was blocked by the same local Rust toolchain version mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dad8a16083308f9fb1887657ca67)