### PR TITLE
Correct release version references to v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.0.0] - 2026-02-28
+## [1.1.3] - 2026-02-28
 
 ### Added
 - Embedded Trippy runtime inside `mtr.exe`, removing the external `trip.exe` runtime dependency.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-mtr"
-version = "2.0.0"
+version = "1.1.3"
 edition = "2024"
 authors = ["Benji Shohet <benjisho>"]
 description = "Windows-native clone of Linux mtr — cross-platform Rust CLI for ICMP/TCP/UDP traceroute & ping"

--- a/README.md
+++ b/README.md
@@ -289,17 +289,17 @@ mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://loggin
 <tr>
   <td>Single portable executable</td>
   <td>✅ Released</td>
-  <td>v2.0.0</td>
+  <td>v1.1.3</td>
 </tr>
 <tr>
   <td>JSON Output</td>
   <td>✅ Released</td>
-  <td>v2.0.0</td>
+  <td>v1.1.3</td>
 </tr>
 <tr>
   <td>DNS Caching (TTL)</td>
   <td>✅ Released</td>
-  <td>v2.0.0</td>
+  <td>v1.1.3</td>
 </tr>
 <tr>
   <td>REST API</td>

--- a/packaging/scoop/windows-mtr.json
+++ b/packaging/scoop/windows-mtr.json
@@ -1,11 +1,11 @@
 {
-  "version": "2.0.0",
+  "version": "1.1.3",
   "description": "Windows-native drop-in replacement for Linux mtr",
   "homepage": "https://github.com/benjisho/windows-mtr",
   "license": "Apache-2.0",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/benjisho/windows-mtr/releases/download/v2.0.0/windows-mtr-2.0.0-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/benjisho/windows-mtr/releases/download/v1.1.3/windows-mtr-1.1.3-x86_64-pc-windows-msvc.zip",
       "hash": "REPLACE_WITH_RELEASE_SHA256"
     }
   },

--- a/packaging/winget/windows-mtr.installer.yaml
+++ b/packaging/winget/windows-mtr.installer.yaml
@@ -1,9 +1,9 @@
 PackageIdentifier: benjisho.windows-mtr
-PackageVersion: 2.0.0
+PackageVersion: 1.1.3
 InstallerType: zip
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/benjisho/windows-mtr/releases/download/v2.0.0/windows-mtr-2.0.0-x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/benjisho/windows-mtr/releases/download/v1.1.3/windows-mtr-1.1.3-x86_64-pc-windows-msvc.zip
     InstallerSha256: REPLACE_WITH_RELEASE_SHA256
     NestedInstallerType: portable
     NestedInstallerFiles:

--- a/packaging/winget/windows-mtr.locale.en-US.yaml
+++ b/packaging/winget/windows-mtr.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: benjisho.windows-mtr
-PackageVersion: 2.0.0
+PackageVersion: 1.1.3
 PackageLocale: en-US
 Publisher: Benji Shohet
 PackageName: windows-mtr

--- a/packaging/winget/windows-mtr.yaml
+++ b/packaging/winget/windows-mtr.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: benjisho.windows-mtr
-PackageVersion: 2.0.0
+PackageVersion: 1.1.3
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0


### PR DESCRIPTION
### Motivation
- The repository incorrectly referenced `2.0.0` / `v2.0.0` in multiple metadata and packaging files despite the released version being `1.1.3`, which could confuse installers and consumers.
- This change aims to make packaging manifests, release URLs, and documentation consistent with the actual release to avoid publishing/install failures.

### Description
- Replaced occurrences of `2.0.0`/`v2.0.0` with `1.1.3`/`v1.1.3` across package metadata, packaging manifests, and documentation.
- Updated the crate `version` in `Cargo.toml` to `1.1.3` and adjusted the changelog heading to `## [1.1.3] - 2026-02-28` while keeping the SemVer link canonical.
- Updated release asset URLs in the Scoop and WinGet manifests to point to the `v1.1.3` release artifacts.
- Updated the README feature/release table entries to show `v1.1.3` for the delivered features.

### Testing
- Ran `cargo fmt --all -- --check` which passed successfully.
- Ran `cargo test --all` which failed in this environment due to an installed `rustc 1.87.0` while the project and dependencies require `rustc >= 1.88.0` (toolchain mismatch), so test failures are environmental and not caused by these metadata edits.
- Verified with `rg -n "v2\.0\.0|2\.0\.0"` against the updated files which returned no remaining matches for `2.0.0`/`v2.0.0`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5dacf83c88330920b25c8a79dcebd)