### PR TITLE
docs: add contributor, development, and docs hub with issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Report a reproducible problem in Windows MTR
+labels: [bug]
+---
+
+## Summary
+
+Provide a clear and concise description of the issue.
+
+## Environment
+
+- Windows version:
+- Windows MTR version (`mtr --version`):
+- Installation method (MSI/ZIP/source):
+- Probe mode used (ICMP/TCP/UDP):
+
+## Reproduction Steps
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What did you expect to happen?
+
+## Actual Behavior
+
+What happened instead?
+
+## Command and Output
+
+```text
+# command
+# stdout/stderr
+```
+
+## Additional Context
+
+Include logs, screenshots, packet captures, or related details.
+
+## Security Note
+
+Do not report vulnerabilities here. Please use private security reporting as documented in [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Propose an enhancement for Windows MTR
+labels: [enhancement]
+---
+
+## Problem Statement
+
+What limitation or pain point are you trying to solve?
+
+## Proposed Solution
+
+Describe your preferred behavior or interface.
+
+## Alternatives Considered
+
+Describe alternative approaches you've evaluated.
+
+## Example Usage
+
+```bash
+# Example command(s) or workflow
+```
+
+## Impact
+
+Who benefits and how?
+
+## Compatibility Considerations
+
+Will this impact existing CLI behavior, output format, or automation scripts?
+
+## Additional Context
+
+Add references, links, mockups, or prior art.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Summary
+
+<!-- What changed? -->
+
+## Why
+
+<!-- Why is this change needed? -->
+
+## Changes
+
+- [ ] Code changes
+- [ ] Tests added/updated
+- [ ] Documentation updated
+
+## Testing
+
+<!-- List exact commands run and outcomes -->
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+## Compatibility / Risk Notes
+
+- CLI compatibility impact:
+- Output/report format impact:
+- Operational risk and rollback plan:
+
+## Security Considerations
+
+<!-- Any security implications, threat model changes, or input validation updates? -->
+
+## Checklist
+
+- [ ] I followed the contribution guidelines in `CONTRIBUTING.md`
+- [ ] I ran relevant checks locally
+- [ ] I updated docs/changelog as needed
+- [ ] I confirmed no sensitive data is included

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to Windows MTR
+
+Thank you for your interest in contributing to **Windows MTR**. This guide explains how to contribute safely and efficiently to an enterprise-grade network diagnostics tool.
+
+## Table of Contents
+
+- [Code of Conduct Expectations](#code-of-conduct-expectations)
+- [Before You Start](#before-you-start)
+- [Development Workflow](#development-workflow)
+- [Testing Requirements](#testing-requirements)
+- [Documentation Requirements](#documentation-requirements)
+- [Security Reporting](#security-reporting)
+- [Release Process Overview](#release-process-overview)
+- [Getting Help](#getting-help)
+
+## Code of Conduct Expectations
+
+By participating in this project, you agree to:
+
+- Be respectful and constructive in all discussions.
+- Assume good intent while giving clear, actionable feedback.
+- Focus on technical outcomes and user impact.
+- Avoid harassment, discrimination, and hostile behavior.
+
+If you encounter unacceptable behavior, open a private maintainer contact through a GitHub issue asking for a confidential follow-up.
+
+## Before You Start
+
+1. Read the main [README](README.md).
+2. Review command behavior in [USAGE.md](USAGE.md) and [docs/USAGE.md](docs/USAGE.md).
+3. Check open issues and existing pull requests to avoid duplicated effort.
+
+For local setup details, see [DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Development Workflow
+
+1. **Fork and branch**
+   - Create a topic branch with a clear name: `fix/icmp-timeout`, `docs/usage-json`.
+2. **Keep changes minimal**
+   - Prefer small, reviewable pull requests.
+   - Preserve CLI compatibility unless intentionally documented.
+3. **Implement with safety first**
+   - Treat CLI input, hostnames, packets, and files as untrusted input.
+4. **Validate locally**
+   - Run formatting, linting, and tests before opening a PR.
+5. **Open a pull request**
+   - Use `.github/PULL_REQUEST_TEMPLATE.md`.
+   - Clearly describe what changed, why, and how you tested it.
+
+## Testing Requirements
+
+Run these checks before submitting:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+If any command cannot run in your environment, include:
+
+- The exact command
+- The exact failure output
+- Why the limitation is environmental
+
+## Documentation Requirements
+
+Update docs whenever you change:
+
+- CLI flags/options/default behavior
+- Report/output formats (table/JSON)
+- Build or installation instructions
+
+Recommended docs to update:
+
+- [README.md](README.md)
+- [USAGE.md](USAGE.md)
+- [docs/README.md](docs/README.md)
+- [docs/API.md](docs/API.md)
+
+## Security Reporting
+
+Do **not** disclose vulnerabilities publicly in issues.
+
+Instead:
+
+1. Open a private security advisory in GitHub Security (preferred), or
+2. Open an issue requesting private security contact details without exposing exploit details.
+
+Include impact, affected versions, reproduction details, and mitigation ideas.
+
+## Release Process Overview
+
+High-level release flow:
+
+1. Update relevant docs and `CHANGELOG.md`.
+2. Ensure CI checks pass for all targets.
+3. Tag and publish release artifacts (MSI, ZIP, checksums/signatures if available).
+4. Validate installation and smoke-test core probe modes (ICMP/TCP/UDP).
+
+For local contributor work, you usually only need to ensure your changes are release-ready and documented.
+
+## Getting Help
+
+- Usage questions: open a GitHub discussion/issue with command examples and outputs.
+- Bug reports: use the [bug template](.github/ISSUE_TEMPLATE/bug_report.md).
+- Feature proposals: use the [feature template](.github/ISSUE_TEMPLATE/feature_request.md).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,110 @@
+# Development Guide
+
+This document covers local setup, day-to-day development workflow, and troubleshooting for **Windows MTR**.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Clone and Build](#clone-and-build)
+- [Local Workflow](#local-workflow)
+- [Testing and Quality Gates](#testing-and-quality-gates)
+- [Project Layout](#project-layout)
+- [Troubleshooting](#troubleshooting)
+- [Related Documentation](#related-documentation)
+
+## Prerequisites
+
+### Required
+
+- Rust toolchain (Rust 1.88.0+ recommended)
+- Git
+
+### Windows builds
+
+- Visual Studio Build Tools with **Desktop development with C++** workload
+- Administrator shell for raw socket/probe-related runtime tests
+
+### Optional but useful
+
+- `cargo-audit` for security checks
+- `cargo-nextest` for faster local test loops
+
+## Clone and Build
+
+```bash
+git clone https://github.com/benjisho/windows-mtr.git
+cd windows-mtr
+cargo build
+```
+
+Release build:
+
+```bash
+cargo build --release
+```
+
+Run CLI help:
+
+```bash
+cargo run -- --help
+```
+
+## Local Workflow
+
+1. Create a branch from latest main/master.
+2. Implement a focused change.
+3. Add/update tests for behavior changes.
+4. Update docs when CLI/output/install behavior changes.
+5. Run quality gates before pushing.
+
+Recommended commit style: imperative and specific, e.g. `docs: add API guide for JSON output`.
+
+## Testing and Quality Gates
+
+Run all checks when possible:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+```
+
+Targeted test examples:
+
+```bash
+cargo test --test cli_tests
+cargo test --test report_tests
+```
+
+## Project Layout
+
+- `src/` — core application code
+- `tests/` — integration, unit, and report-focused tests
+- `examples/` — usage and integration examples
+- `xtask/` — automation helpers
+- `docs/` — expanded project documentation
+
+## Troubleshooting
+
+### Build fails with linker/toolchain errors (Windows)
+
+- Confirm Visual Studio Build Tools are installed.
+- Ensure the `x86_64-pc-windows-msvc` target is active.
+
+### Runtime probe behavior differs without admin rights
+
+- Some probe modes depend on privileges/capabilities.
+- Re-run in elevated terminal for diagnostics.
+
+### DNS or ASN results look inconsistent
+
+- Use `-n` to isolate DNS from routing/probe behavior.
+- Compare JSON output across multiple runs to confirm variability.
+
+## Related Documentation
+
+- [Contributing Guidelines](CONTRIBUTING.md)
+- [Documentation Index](docs/README.md)
+- [Installation Guide](docs/INSTALLATION.md)
+- [Usage Guide](docs/USAGE.md)
+- [API Reference](docs/API.md)

--- a/README.md
+++ b/README.md
@@ -279,9 +279,11 @@ mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://loggin
 
 ## 📋 Documentation
 
-- [📚 Full Documentation](#-documentation)
-- [🧩 API Reference](https://pkg.rs/crates/windows_mtr)
-- [📑 Usage Examples](USAGE.md)
+- [📚 Full Documentation Hub](docs/README.md)
+- [🧩 CLI/API Reference](docs/API.md)
+- [📑 Usage Examples](docs/USAGE.md)
+- [🛠️ Development Setup](DEVELOPMENT.md)
+- [🤝 Contributing Guide](CONTRIBUTING.md)
 - [🔄 Changelog](CHANGELOG.md)
 
 ## 📊 Project Status & Roadmap

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,72 @@
+# API Reference
+
+Windows MTR is primarily a CLI application. This document defines its operational API surfaces for automation:
+
+1. Command-line interface (flags/options)
+2. Exit behavior
+3. Structured report output (JSON)
+
+## CLI Interface
+
+Base syntax:
+
+```bash
+mtr [options] <hostname-or-ip>
+```
+
+Primary categories:
+
+- **Probe selection:** `-T`, `-U`, `-P`, `--source-port`
+- **Routing scope:** `-m`, `-S`, `--interface`
+- **Output mode:** `-r`, `-w`, `--json`, `--json-pretty`
+- **Sampling/timing:** `-c`, `-i`, `-W`
+- **Name/ASN rendering:** `-n`, `-b`, `-z`
+
+For full option examples, see [USAGE.md](USAGE.md) and [../USAGE.md](../USAGE.md).
+
+## Exit Behavior
+
+Typical expectations:
+
+- `0` for successful command execution and report generation
+- non-zero for invalid arguments, runtime/probe errors, or initialization failures
+
+Automation guidance:
+
+- Check exit code first
+- Parse stdout only on success
+- Capture stderr for diagnostic logging
+
+## JSON Output Contract
+
+When `--json` or `--json-pretty` is used, output is machine-readable and intended for downstream tooling.
+
+Example pattern:
+
+```bash
+mtr --json -c 10 1.1.1.1 > mtr-report.json
+```
+
+Consumer best practices:
+
+- Treat unknown fields as forward-compatible additions.
+- Avoid strict ordering assumptions.
+- Validate required fields in your own schema.
+
+## Compatibility Notes
+
+- CLI compatibility with Linux `mtr` is a goal, but not every flag is identical.
+- `--trippy-flags` may expose advanced behavior from underlying implementation.
+- Cross-platform/runtime differences may affect network probe behavior.
+
+## Security Considerations for Integrators
+
+- Treat all target/input values as untrusted.
+- Avoid logging sensitive destination metadata in shared logs.
+- Run with least privilege where feasible; elevate only when required for diagnostics.
+
+## Related Docs
+
+- [Installation](INSTALLATION.md)
+- [Usage](USAGE.md)
+- [Contributing](../CONTRIBUTING.md)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,100 @@
+# Installation Guide
+
+This guide covers recommended installation methods for Windows MTR.
+
+## Table of Contents
+
+- [System Requirements](#system-requirements)
+- [Install from GitHub Releases](#install-from-github-releases)
+- [Portable Installation](#portable-installation)
+- [Build from Source](#build-from-source)
+- [Verification](#verification)
+- [Uninstall](#uninstall)
+- [Troubleshooting](#troubleshooting)
+
+## System Requirements
+
+- Windows 7 / Server 2012 R2 or later (recommended: modern supported Windows versions)
+- Administrator privileges for full probe capabilities
+- ~50 MB free disk space for binaries and dependencies
+
+## Install from GitHub Releases
+
+Recommended for most users.
+
+1. Open the [latest release page](https://github.com/benjisho/windows-mtr/releases).
+2. Download the MSI package for your architecture.
+3. Run installer as Administrator.
+4. Verify from terminal:
+
+```powershell
+mtr --help
+```
+
+## Portable Installation
+
+1. Download `windows-mtr.zip` (or compressed variant).
+2. Extract to a folder, e.g. `C:\Tools\windows-mtr`.
+3. Run directly:
+
+```powershell
+.\mtr.exe --help
+```
+
+Optional: add folder to `PATH`.
+
+## Build from Source
+
+### Prerequisites
+
+- Rust (1.88.0+)
+- Visual Studio Build Tools (Desktop development with C++)
+
+### Build steps
+
+```bash
+git clone https://github.com/benjisho/windows-mtr.git
+cd windows-mtr
+cargo build --release
+```
+
+Binary output:
+
+- `target\release\mtr.exe`
+
+## Verification
+
+Run a quick report test:
+
+```powershell
+mtr -r -c 5 8.8.8.8
+```
+
+JSON verification:
+
+```powershell
+mtr --json -c 5 1.1.1.1
+```
+
+## Uninstall
+
+- MSI install: remove via **Apps & Features**.
+- Portable install: delete extracted folder and any PATH entry.
+
+## Troubleshooting
+
+### Command not found
+
+- Restart terminal after modifying PATH.
+- Use full path to `mtr.exe` to verify binary is valid.
+
+### Insufficient privileges
+
+- Launch terminal as Administrator and rerun command.
+
+### Endpoint filtering blocks probes
+
+- Validate local firewall/network security policy.
+- Try different protocol mode (`-T` or `-U`) for diagnostics.
+
+For operational usage details, see [USAGE.md](USAGE.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# Windows MTR Documentation
+
+Welcome to the documentation hub for **Windows MTR**, a Windows-native, enterprise-grade network diagnostics tool inspired by Linux `mtr`.
+
+## Start Here
+
+- [Installation Guide](INSTALLATION.md)
+- [Usage Guide](USAGE.md)
+- [API Reference](API.md)
+- [Development Guide](../DEVELOPMENT.md)
+- [Contributing Guide](../CONTRIBUTING.md)
+
+## Documentation Map
+
+- **User docs**
+  - [Project README](../README.md)
+  - [Quick usage reference](../USAGE.md)
+  - [Detailed usage](USAGE.md)
+- **Engineering docs**
+  - [Development setup and workflow](../DEVELOPMENT.md)
+  - [Contribution process and quality gates](../CONTRIBUTING.md)
+  - [CLI/report API semantics](API.md)
+
+## Common Tasks
+
+- Install for production use: [INSTALLATION.md](INSTALLATION.md)
+- Understand command patterns: [USAGE.md](USAGE.md)
+- Integrate JSON output into automation: [API.md](API.md)
+- Contribute fixes or features: [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,106 @@
+# Usage Guide
+
+This guide provides practical command patterns for Windows MTR.
+
+## Command Syntax
+
+```bash
+mtr [options] <hostname-or-ip>
+```
+
+## Core Probe Modes
+
+### ICMP (default)
+
+```bash
+mtr 8.8.8.8
+```
+
+### TCP SYN
+
+```bash
+mtr -T -P 443 github.com
+```
+
+### UDP
+
+```bash
+mtr -U -P 53 1.1.1.1
+```
+
+## Report and Automation Modes
+
+### Pretty report
+
+```bash
+mtr -r -c 10 example.com
+```
+
+### Wide report
+
+```bash
+mtr -r -w -c 10 example.com
+```
+
+### JSON report
+
+```bash
+mtr --json -c 20 8.8.4.4
+```
+
+### Pretty JSON
+
+```bash
+mtr --json-pretty -c 20 8.8.4.4
+```
+
+## Useful Flags
+
+- `-n` — disable reverse DNS
+- `-b` / `--show-asn` — include ASN info
+- `-m <hops>` — max hops/TTL
+- `-i <seconds>` — minimum round duration
+- `-W <seconds>` — probe grace timeout
+- `-S <ip>` — source IP
+- `--interface <name>` — source interface
+
+## Common Workflows
+
+### Validate HTTPS path stability
+
+```bash
+mtr -T -P 443 -r -c 25 your-service.example
+```
+
+### Compare DNS-on vs DNS-off latency visibility
+
+```bash
+mtr -r -c 15 your-target.example
+mtr -r -n -c 15 your-target.example
+```
+
+### Feed JSON output into automation
+
+```bash
+mtr --json -c 30 your-target.example > report.json
+```
+
+See [API.md](API.md) for JSON/report field guidance.
+
+## Troubleshooting
+
+### No response from first hops
+
+- This can be normal due to ICMP filtering/rate-limiting.
+- Compare with TCP mode: `mtr -T -P 443 ...`.
+
+### Inconsistent results between runs
+
+- Increase cycles (`-c`) to smooth transient variation.
+- Run during similar traffic windows for comparison.
+
+### Name resolution appears slow
+
+- Disable reverse DNS (`-n`) to isolate probe timing from DNS overhead.
+
+For concise option reference, see [../USAGE.md](../USAGE.md).


### PR DESCRIPTION
### Motivation

- Provide an industry-standard documentation baseline so users and contributors can find installation, usage, API, and development guidance in a single, navigable docs hub.
- Surface contribution expectations, security reporting guidance, and testing/quality gates to improve reviewability and reduce risky changes.
- Supply GitHub-native templates to streamline reproducible bug reports, feature requests, and PRs for consistent triage.

### Description

- Added contributor and onboarding content in `CONTRIBUTING.md` covering code of conduct, workflow, testing, docs, security reporting, and release notes. 
- Added developer-focused guidance in `DEVELOPMENT.md` with prerequisites, build steps, local workflow, quality gates, and troubleshooting. 
- Created a documentation hub under `docs/` with `docs/README.md`, `docs/INSTALLATION.md`, `docs/USAGE.md`, and `docs/API.md` that include examples, cross-links, and troubleshooting content suitable for GitHub Pages. 
- Added GitHub templates: `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md`, and `.github/PULL_REQUEST_TEMPLATE.md`, and updated the main `README.md` documentation links to point to the new docs hub, and prepared the change for review.

### Testing

- Ran formatting checks with `cargo fmt --all -- --check`, which completed successfully. 
- Ran linting with `cargo clippy --all-targets --all-features -- -D warnings`, which failed due to the environment `rustc 1.87.0` while the project and dependencies require `rustc 1.88.0+`. 
- Ran unit/integration tests with `cargo test --all`, which could not run for the same `rustc` toolchain version mismatch (`1.87.0` vs required `1.88.0+`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62a1ce108833096193c6052ab0cc9)