### PR TITLE
Cache Rust dependencies and binaries in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           toolchain: 1.88.0
 
+      - name: Cache Cargo dependencies and installed binaries
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          shared-key: "rust-security-1.88.0"
+          cache-bin: true
+          cache-on-failure: true
+
       - name: Run cargo-deny
         id: cargo_deny
         uses: EmbarkStudios/cargo-deny-action@v2


### PR DESCRIPTION
### Motivation
- Reduce CI runtime and repeated network installs by caching Cargo dependencies and installed binaries for the `security` workflow, and limit saving to the `master` branch to avoid polluting cache from PRs.

### Description
- Add a caching step to `.github/workflows/security.yml` using `Swatinem/rust-cache@v2` with `save-if: ${{ github.ref == 'refs/heads/master' }}`, `shared-key: "rust-security-1.88.0"`, `cache-bin: true`, and `cache-on-failure: true` while keeping the existing Rust toolchain and security checks (`cargo-deny` and `cargo-audit`).

### Testing
- No automated tests were run as part of this change; the workflow will exercise the cache behavior on subsequent CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6314f7c588330a70b420b652167a0)