### PR TITLE
Publish Docker image to GHCR and add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,9 @@ target
 *.md
 assets
 packaging
-xtask
+xtask/*
+!xtask/Cargo.toml
+!xtask/src/**
 skills
 tests
 examples

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+target
+.gitignore
+.DS_Store
+*.md
+assets
+packaging
+xtask
+skills
+tests
+examples
+docs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,45 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
 
+
+  docker-amd64:
+    name: Docker Build/Test (linux/amd64)
+    runs-on: ubuntu-latest
+    needs: [test-msrv, test-stable]
+    if: needs.test-msrv.result == 'success' && (needs.test-stable.result == 'success' || needs.test-stable.result == 'skipped')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (linux/amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: windows-mtr:ci-amd64
+          cache-from: type=gha,scope=ci-docker-amd64
+          cache-to: type=gha,scope=ci-docker-amd64,mode=max
+          provenance: false
+          sbom: false
+
+      - name: Smoke test container
+        run: |
+          docker run --rm windows-mtr:ci-amd64 --help
+          docker run --rm windows-mtr:ci-amd64 --version
+
   # New job to build binaries during pull requests for testing
   build-pr-binaries:
     name: Build PR Binaries
     runs-on: windows-latest
-    needs: [test-msrv, test-stable]
+    needs: [test-msrv, test-stable, docker-amd64]
     if: github.event_name == 'pull_request' && (needs.test-stable.result == 'success' || needs.test-stable.result == 'skipped')
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build and Test
@@ -191,11 +198,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Normalize image name
+        id: image
+        shell: bash
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
       - name: Extract image metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/windows-mtr
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=tag
@@ -210,6 +222,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
 
   # Only run for tag pushes (real releases)
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,10 +165,58 @@ jobs:
           }
         shell: pwsh
 
+
+  publish-package:
+    name: Publish GHCR Package
+    needs: build
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/windows-mtr
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=semver,pattern={{version}},value=${{ github.ref_name }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   # Only run for tag pushes (real releases)
   release:
     name: Create Release
-    needs: build
+    needs:
+      - build
+      - publish-package
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
     # Add explicit permissions for creating releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
           images: ${{ steps.image.outputs.name }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=tag
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=semver,pattern={{version}},value=${{ github.ref_name }}
 
       - name: Build and push image

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,12 @@ FROM debian:trixie-slim AS runtime
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 10001 appuser \
+    && useradd --system --uid 10001 --gid appuser --home /nonexistent --shell /usr/sbin/nologin appuser
 
 COPY --from=builder /app/target/release/mtr /usr/local/bin/windows-mtr
+RUN ln -s /usr/local/bin/windows-mtr /usr/local/bin/mtr
 
+USER appuser
 ENTRYPOINT ["/usr/local/bin/windows-mtr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+
+FROM rust:1.93.1-slim-trixie AS builder
+WORKDIR /app
+
+# Build dependency layer first for better cache reuse.
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src ./src
+
+RUN cargo build --release --locked --bin mtr
+
+FROM debian:trixie-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/target/release/mtr /usr/local/bin/windows-mtr
+
+ENTRYPOINT ["/usr/local/bin/windows-mtr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ COPY xtask/Cargo.toml ./xtask/Cargo.toml
 COPY xtask/src ./xtask/src
 COPY src ./src
 
-RUN cargo build --release --locked --bin mtr
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --locked --bin mtr
 
 FROM debian:trixie-slim AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 
 # Build dependency layer first for better cache reuse.
 COPY Cargo.toml Cargo.lock build.rs ./
+COPY xtask/Cargo.toml ./xtask/Cargo.toml
+COPY xtask/src ./xtask/src
 COPY src ./src
 
 RUN cargo build --release --locked --bin mtr

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ docker pull ghcr.io/benjisho/windows-mtr:v1.0.0
 docker run --network host ghcr.io/benjisho/windows-mtr:latest -c 5 -r 8.8.8.8
 ```
 
-Container images are published to GHCR from the `Release` workflow for `master` (`latest`) and version tags (`v*.*.*`).
+Container images are published to GHCR from the `Release` workflow as both `latest` (from `master`) and explicit release tags like `v1.2.3`.
 
 > [!NOTE]
 > Windows container networking can vary by environment. If `--network host` is not available in your setup, run the binary directly on the host for full probe capability.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,14 @@ Windows MTR is built with enterprise-level security practices:
 # Pull the latest Windows MTR container
 docker pull ghcr.io/benjisho/windows-mtr:latest
 
+# Or pin to a release tag
+docker pull ghcr.io/benjisho/windows-mtr:v1.0.0
+
 # Run with direct networking
-docker run --network host ghcr.io/benjisho/windows-mtr -c 5 -r 8.8.8.8
+docker run --network host ghcr.io/benjisho/windows-mtr:latest -c 5 -r 8.8.8.8
 ```
+
+Container images are published to GHCR from the `Release` workflow for `master` (`latest`) and version tags (`v*.*.*`).
 
 > [!NOTE]
 > Windows container networking can vary by environment. If `--network host` is not available in your setup, run the binary directly on the host for full probe capability.


### PR DESCRIPTION
### Motivation

- Provide an official container image for the project and automate publishing to GitHub Container Registry (GHCR) from the release workflow. 
- Improve repository support for container builds and dependency automation (Dependabot) and avoid packaging irrelevant files in images via `.dockerignore`.

### Description

- Add a multi-stage `Dockerfile` that builds the `mtr` binary with Rust and produces a slim Debian runtime image exposing the binary as `/usr/local/bin/windows-mtr`.
- Add `.dockerignore` to exclude VCS, docs, examples, tests, and other non-runtime files from image context.
- Add `.github/dependabot.yml` to enable weekly updates for GitHub Actions and Docker dependencies.
- Update the release workflow (`.github/workflows/release.yml`) to include a new `publish-package` job that builds and pushes the container to GHCR using `docker/build-push-action@v6` with `docker/metadata-action@v5`, and make the `release` job depend on the package publish step; also add QEMU and Buildx setup and GHCR login steps.
- Update `README.md` to show how to pull the published container image and note GHCR publishing behavior.

### Testing

- No automated tests were executed as part of this PR; CI workflow updates were added but not run within this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6429147508330a0170646ba5db42e)