### PR TITLE
Publish container images to both GHCR and Docker Hub and update README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
 
 
   publish-package:
-    name: Publish GHCR Package
+    name: Publish Container Packages
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
@@ -202,16 +202,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Normalize image name
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Normalize image names
         id: image
         shell: bash
-        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "ghcr=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+          echo "dockerhub=benjisho/windows-mtr" >> "$GITHUB_OUTPUT"
 
       - name: Extract image metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ steps.image.outputs.name }}
+          images: |
+            ${{ steps.image.outputs.ghcr }}
+            ${{ steps.image.outputs.dockerhub }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,7 @@ jobs:
     needs: build
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
+    environment: publish-container-packages
     permissions:
       contents: read
       packages: write

--- a/README.md
+++ b/README.md
@@ -120,17 +120,23 @@ Windows MTR is built with enterprise-level security practices:
 ### Docker
 
 ```bash
-# Pull the latest Windows MTR container
+# Pull the latest Windows MTR container (GHCR)
 docker pull ghcr.io/benjisho/windows-mtr:latest
+
+# Pull the latest Windows MTR container (Docker Hub)
+docker pull benjisho/windows-mtr:latest
 
 # Or pin to a release tag
 docker pull ghcr.io/benjisho/windows-mtr:v1.0.0
+
+# Or pin to a release tag from Docker Hub
+docker pull benjisho/windows-mtr:v1.0.0
 
 # Run with direct networking
 docker run --network host ghcr.io/benjisho/windows-mtr:latest -c 5 -r 8.8.8.8
 ```
 
-Container images are published to GHCR from the `Release` workflow as both `latest` (from `master`) and explicit release tags like `v1.2.3` for `linux/amd64` and `linux/arm64`.
+Container images are published from the `Release` workflow to both GHCR (`ghcr.io/benjisho/windows-mtr`) and Docker Hub (`benjisho/windows-mtr`) as `latest` (from `master`) and explicit release tags like `v1.2.3` for `linux/amd64` and `linux/arm64`.
 
 > [!NOTE]
 > Windows container networking can vary by environment. If `--network host` is not available in your setup, run the binary directly on the host for full probe capability.


### PR DESCRIPTION
### Motivation
- Add Docker Hub as a second publishing target so container images are available from both GHCR and Docker Hub.
- Update user documentation to reflect the new Docker Hub image and provide pull examples.

### Description
- Renamed the publish job to "Publish Container Packages" and added a Docker Hub login step using `secrets.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_TOKEN`.
- Normalized and exported two image names (`ghcr` and `dockerhub`) and passed both to `docker/metadata-action` so tags/labels are generated for each registry.
- Kept the `docker/build-push-action` build and push configuration for `linux/amd64` and `linux/arm64` with existing cache, SBOM, and provenance settings.
- Updated `README.md` to include `docker pull benjisho/windows-mtr:latest` and pinned tag examples for Docker Hub, and clarified where images are published.

### Testing
- Ran the repository CI which executed the `build` job including `cargo test` and binary verification, and it completed successfully.
- Validated the release workflow changes with a workflow syntax check and a local dry-run of metadata extraction, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6d95314648330aca9681ee984d606)