### PR TITLE
Refresh README roadmap with remaining high-impact gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,12 +345,42 @@ mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://loggin
 <tr>
   <td>REST API</td>
   <td>📅 Planned</td>
-  <td>Q4 2025</td>
+  <td>H2 2026</td>
 </tr>
 <tr>
   <td>SNMP Integration</td>
   <td>📅 Planned</td>
-  <td>Q4 2025</td>
+  <td>H2 2026</td>
+</tr>
+<tr>
+  <td>Native Ratatui UI (tabs, hop table, charts)</td>
+  <td>🛣️ Roadmap</td>
+  <td>H2 2026</td>
+</tr>
+<tr>
+  <td>ETW + Windows observability integrations</td>
+  <td>🛣️ Roadmap</td>
+  <td>H2 2026</td>
+</tr>
+<tr>
+  <td>Versioned JSON schema + CSV export</td>
+  <td>🛣️ Roadmap</td>
+  <td>H2 2026</td>
+</tr>
+<tr>
+  <td>Security hardening gates (cargo-audit + fuzz harness in CI)</td>
+  <td>🛣️ Roadmap</td>
+  <td>H2 2026</td>
+</tr>
+<tr>
+  <td>Cross-platform probe parity/privilege smoke tests</td>
+  <td>🛣️ Roadmap</td>
+  <td>H2 2026</td>
+</tr>
+<tr>
+  <td>CLI/runtime cleanup (unused error variants, banner polish)</td>
+  <td>🛣️ Roadmap</td>
+  <td>H2 2026</td>
 </tr>
 </table>
 


### PR DESCRIPTION
### Motivation
- The README contained stale timelines (Q4 2025) and omitted several high-impact gaps identified during a recent repository review. 
- Updating the roadmap helps contributors and users prioritize work and aligns public planning with the repository's current state. 

### Description
- Updated the roadmap table in `README.md` to move `REST API` and `SNMP Integration` timelines from `Q4 2025` to `H2 2026` and added several roadmap entries.  
- Added roadmap rows for: `Native Ratatui UI (tabs, hop table, charts)`, `ETW + Windows observability integrations`, `Versioned JSON schema + CSV export`, `Security hardening gates (cargo-audit + fuzz harness in CI)`, `Cross-platform probe parity/privilege smoke tests`, and `CLI/runtime cleanup (unused error variants, banner polish)`.  
- This is a documentation-only change that does not modify code paths, runtime behavior, or packaging.

### Testing
- Verified the README changes with automated checks using `git diff -- README.md` and inspected the updated region with `nl -ba README.md | sed -n '330,390p'`, both succeeding.  
- Confirmed the file was committed (`git status --short`) and the commit message `Update roadmap with outstanding feature gaps` was created, indicating the documentation update was recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7655e5fac8330a4fbd42ced7eac58)