### PR TITLE
Add Docker Scout GitHub Actions workflow for PR image comparisons

### DIFF
--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -1,0 +1,75 @@
+name: Docker Scout
+
+on:
+  push:
+    branches: [ master ]
+    tags: ["v*"]
+  pull_request:
+    branches: ["**"]
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: benjisho/windows-mtr
+  SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  docker-scout-compare:
+    name: Build image and compare with production
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Authenticate to registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.revision=${{ env.SHA }}
+          tags: |
+            type=edge,branch=master
+            type=semver,pattern=v{{version}}
+            type=sha,prefix=,suffix=,format=short
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          sbom: ${{ github.event_name != 'pull_request' }}
+          provenance: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Docker Scout compare with production
+        id: docker-scout
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: docker/scout-action@v1
+        with:
+          command: compare
+          image: ${{ steps.meta.outputs.tags }}
+          to-env: production
+          ignore-unchanged: true
+          only-severities: critical,high
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ docker run --network host ghcr.io/benjisho/windows-mtr:latest -c 5 -r 8.8.8.8
 
 Container images are published from the `Release` workflow to both GHCR (`ghcr.io/benjisho/windows-mtr`) and Docker Hub (`benjisho/windows-mtr`) as `latest` (from `master`) and explicit release tags like `v1.2.3` for `linux/amd64` and `linux/arm64`.
 
+Pull requests also run a dedicated `Docker Scout` workflow (`.github/workflows/docker-scout.yml`) that builds the proposed image and compares it against the `production` environment baseline in Docker Scout. Configure `REGISTRY_USER` and `REGISTRY_TOKEN` repository secrets (Docker Hub credentials) and enable the `production` Scout environment for meaningful comparisons.
+
 > [!NOTE]
 > Windows container networking can vary by environment. If `--network host` is not available in your setup, run the binary directly on the host for full probe capability.
 


### PR DESCRIPTION
### Motivation
- Add automated image-level policy and vulnerability comparisons into pull request validation by integrating Docker Scout so reviewers can see how a proposed image differs from the `production` baseline before merging.

### Description
- Added a new CI workflow at `.github/workflows/docker-scout.yml` which builds the Docker image (uses `docker/setup-buildx-action` and `docker/build-push-action`), loads the image for PRs, and runs `docker/scout-action@v1` with `command: compare` against the `production` Scout environment.
- The workflow handles push/tag events (push/publish behavior) and pull requests (local `load` + Scout comparison) and expects repository secrets `REGISTRY_USER` and `REGISTRY_TOKEN` for registry authentication.
- Updated `README.md` to document the new `Docker Scout` workflow and the required repository secrets and Scout environment configuration.

### Testing
- Ran `cargo fmt --all -- --check` which passed successfully.
- `cargo clippy --all-targets --all-features -- -D warnings` initially failed under the default toolchain (`rustc 1.87.0`) due to dependency MSRV requirements, then `rustup toolchain install 1.88.0` was used and `cargo +1.88.0 clippy --all-targets --all-features -- -D warnings` completed successfully.
- Verified functionality with `cargo +1.88.0 test --all`, and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a862aad7c48330b4754166d55574c3)