### PR TITLE
Add CodeQL workflow for Rust and Actions scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/.gitignore'
+      - '.gitignore'
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/.gitignore'
+      - '.gitignore'
+  schedule:
+    - cron: '20 21 * * 3'
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+            os: ubuntu-latest
+          - language: rust
+            build-mode: autobuild
+            os: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
### Motivation
- Add first-party static security scanning (CodeQL) for workflow definitions and Rust code to catch vulnerabilities and misconfigurations early in CI.

### Description
- Introduce a new workflow at `.github/workflows/codeql.yml` that triggers on `workflow_dispatch`, pushes/PRs to `master`, and a weekly schedule, configures permissions (`security-events: write`, read-only `actions`/`contents`), and runs a matrix for `actions` (`build-mode: none`) and `rust` (`build-mode: autobuild`) using `github/codeql-action/init@v4` and `github/codeql-action/analyze@v4`.

### Testing
- Verified formatting with `cargo fmt --all -- --check` which succeeded.
- Validated the workflow YAML by loading it with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codeql.yml')"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a864cca6f08330aa32c211a33ccd07)