### PR TITLE
Gate CodeQL workflow behind explicit advanced-setup variable

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   analyze:
+    if: ${{ vars.CODEQL_ADVANCED_ENABLED == 'true' }}
     name: Analyze (${{ matrix.language }})
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
### Motivation
- Prevent the CodeQL `analyze` job from running an advanced configuration by default because GitHub rejected uploaded SARIF with: "CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled." 

### Description
- Add a job-level conditional `if: ${{ vars.CODEQL_ADVANCED_ENABLED == 'true' }}` to `jobs.analyze` in `.github/workflows/codeql.yml` so the analyze job only runs when the repository variable is explicitly enabled.

### Testing
- Reviewed the workflow diff to confirm a single-line conditional was added and attempted to run a local YAML parse via Python but the environment lacks `PyYAML`, so parse validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86b2b30548330a510dd5824648874)