### PR TITLE
Disable SARIF upload in CodeQL advanced workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,3 +51,6 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: /language:${{ matrix.language }}
+          # Keep this workflow compatible with repositories that have
+          # Code Scanning default setup enabled.
+          upload: false


### PR DESCRIPTION
### Motivation
- Prevent CodeQL SARIF processing conflicts when the repository also has the GitHub Code Scanning default setup enabled by avoiding double SARIF uploads from the advanced workflow (`.github/workflows/codeql.yml`).

### Description
- Set `upload: false` on `github/codeql-action/analyze@v4` in `.github/workflows/codeql.yml` and add a short inline comment explaining the compatibility rationale.

### Testing
- Verified the updated workflow parses as YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codeql.yml'); puts 'YAML parse ok'"` (succeeded) and attempted `actionlint` linting but it is not installed in this environment (could not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86b2b30548330a510dd5824648874)