### PR TITLE
Guard Docker Scout registry login behind credential availability

### DIFF
--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Authenticate to registry ${{ env.REGISTRY }}
+        if: ${{ secrets.REGISTRY_USER != '' && secrets.REGISTRY_TOKEN != '' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
### Motivation
- Prevent the Docker login step in the Docker Scout workflow from hard-failing PR runs that do not have access to Docker Hub credentials by ensuring the step only runs when both registry secrets are present.

### Description
- Added a conditional to the `Authenticate to registry` step in `.github/workflows/docker-scout.yml` so the step is executed only when `if: ${{ secrets.REGISTRY_USER != '' && secrets.REGISTRY_TOKEN != '' }}` is true, leaving behavior unchanged when secrets are configured.

### Testing
- Parsed the modified workflow with Ruby using `ruby -ryaml -e "YAML.load_file('.github/workflows/docker-scout.yml'); puts 'YAML parse ok'"` which succeeded and validated the YAML syntax.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a877bbf5d48330904aca8e1d4cbe0a)