### PR TITLE
Make `release.yml` the sole tag-release publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 
+# NOTE: This workflow is the sole tag-release publisher for this repository.
+# Keep GitHub release creation on tag pushes here only (release job below).
 on:
   workflow_dispatch:
   # Trigger on push to master branch
@@ -242,7 +244,8 @@ jobs:
           provenance: true
           sbom: true
 
-  # Only run for tag pushes (real releases)
+  # Only run for tag pushes (real releases).
+  # This is the only workflow that publishes GitHub Releases for tags.
   release:
     name: Create Release
     needs:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -3,11 +3,6 @@ name: Windows Build and Release
 on:
   # Manually triggered from GitHub UI
   workflow_dispatch:
-  
-  # On release tag push
-  push:
-    tags:
-      - 'v*'
 
 jobs:
   build-windows:


### PR DESCRIPTION
### Motivation
- Prevent duplicate or competing GitHub Release publication paths by consolidating tag-triggered release creation in a single workflow.

### Description
- Removed the `push.tags` trigger from `.github/workflows/windows-build.yml` (leaving `workflow_dispatch` only) and added top-level comments in `.github/workflows/release.yml` documenting that it is the sole tag-release publisher.

### Testing
- Parsed both updated workflow files as YAML with Ruby (`ruby -e "require 'yaml'; YAML.load_file('.github/workflows/windows-build.yml'); YAML.load_file('.github/workflows/release.yml'); puts 'YAML OK'"`) and reviewed the `git diff` to ensure only the intended trigger removal and comment insertions were made.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87f79425c83308b838d0ab3bbf278)