### PR TITLE
Limit Docker Scout workflow to container-impacting PR paths

### DIFF
--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -6,6 +6,16 @@ on:
     tags: ["v*"]
   pull_request:
     branches: ["**"]
+    # Skip docs-only PRs to reduce container CI cost and improve queue efficiency.
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - Cargo.toml
+      - Cargo.lock
+      - src/**
+      - packaging/**
+      - scripts/**
+      - .github/workflows/docker-scout.yml
 
 env:
   REGISTRY: docker.io


### PR DESCRIPTION
### Motivation

- Avoid running Docker Scout for docs-only changes to reduce CI cost and improve runner queue efficiency.
- Ensure the workflow triggers only for changes that can affect container images or build behavior.

### Description

- Added a `pull_request.paths` filter to `.github/workflows/docker-scout.yml` to scope PR-triggered runs to container/build-impacting files.
- Included these paths: `Dockerfile`, `.dockerignore`, `Cargo.toml`, `Cargo.lock`, `src/**`, `packaging/**`, `scripts/**`, and `.github/workflows/docker-scout.yml`.
- Added a short inline comment explaining that docs-only PRs are excluded to improve CI cost/queue efficiency.

### Testing

- Verified the workflow YAML diff with `git diff -- .github/workflows/docker-scout.yml` and confirmed the new `paths` block is present.
- Inspected the updated file contents with `sed -n '1,90p' .github/workflows/docker-scout.yml` and `nl -ba .github/workflows/docker-scout.yml | sed -n '1,60p'` to confirm the comment and path list.
- Confirmed working tree status with `git status --short` after the change; no repository code/tests were modified because this is a workflow-only update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a880b761688330a0be2712544892b6)