### PR TITLE
Add workflow_run publish gate and reusable publish workflow

### DIFF
--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -1,0 +1,87 @@
+name: Publish Gate
+
+on:
+  workflow_run:
+    workflows: ["CI", "CodeQL", "Security"]
+    types: [completed]
+    branches: [master]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: publish-gate-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate-required-workflows:
+    name: Evaluate required workflow results
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.evaluate.outputs.should_publish }}
+    steps:
+      - name: Evaluate CI/CodeQL/Security conclusions for this SHA
+        id: evaluate
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const required = ["CI", "CodeQL", "Security"];
+            const headSha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner,
+              repo,
+              head_sha: headSha,
+              per_page: 100,
+            });
+
+            const latestByName = new Map();
+            for (const run of runs) {
+              if (!required.includes(run.name)) continue;
+              const current = latestByName.get(run.name);
+              if (!current || run.run_number > current.run_number) {
+                latestByName.set(run.name, run);
+              }
+            }
+
+            const missing = [];
+            const failed = [];
+            const incomplete = [];
+
+            for (const workflowName of required) {
+              const run = latestByName.get(workflowName);
+              if (!run) {
+                missing.push(workflowName);
+                continue;
+              }
+
+              if (run.status !== "completed") {
+                incomplete.push(`${workflowName} (${run.status})`);
+                continue;
+              }
+
+              if (run.conclusion !== "success") {
+                failed.push(`${workflowName} (${run.conclusion})`);
+              }
+            }
+
+            const shouldPublish = missing.length === 0 && failed.length === 0 && incomplete.length === 0;
+            core.setOutput("should_publish", String(shouldPublish));
+
+            if (!shouldPublish) {
+              core.notice(`Publish gate blocked for ${headSha}. Missing: [${missing.join(", ")}], Incomplete: [${incomplete.join(", ")}], Failed: [${failed.join(", ")}].`);
+            } else {
+              core.notice(`All required workflows succeeded for ${headSha}; publish is allowed.`);
+            }
+
+  publish:
+    name: Publish after required workflows
+    needs: evaluate-required-workflows
+    if: needs.evaluate-required-workflows.outputs.should_publish == 'true'
+    uses: ./.github/workflows/reusable-publish.yml
+    secrets: inherit
+    with:
+      publish_latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,7 @@ name: Release
 # Keep GitHub release creation on tag pushes here only (release job below).
 on:
   workflow_dispatch:
-  # Trigger on push to master branch
   push:
-    branches:
-      - master
     tags:
       - 'v*.*.*'
     paths-ignore:
@@ -182,67 +179,11 @@ jobs:
   publish-package:
     name: Publish Container Packages
     needs: build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
-    runs-on: ubuntu-latest
-    environment: publish-container-packages
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Normalize image names
-        id: image
-        shell: bash
-        run: |
-          echo "ghcr=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
-          echo "dockerhub=benjisho/windows-mtr" >> "$GITHUB_OUTPUT"
-
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ steps.image.outputs.ghcr }}
-            ${{ steps.image.outputs.dockerhub }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=semver,pattern={{version}},value=${{ github.ref_name }}
-
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=windows-mtr-release-docker
-          cache-to: type=gha,mode=max,scope=windows-mtr-release-docker
-          provenance: true
-          sbom: true
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/reusable-publish.yml
+    with:
+      publish_latest: false
+    secrets: inherit
 
   # Only run for tag pushes (real releases).
   # This is the only workflow that publishes GitHub Releases for tags.

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -1,0 +1,79 @@
+name: Reusable Publish Containers
+
+on:
+  workflow_call:
+    inputs:
+      publish_latest:
+        description: "Publish the latest tag alongside ref-specific tags"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: reusable-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-package:
+    name: Publish Container Packages
+    runs-on: ubuntu-latest
+    environment: publish-container-packages
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Normalize image names
+        id: image
+        shell: bash
+        run: |
+          echo "ghcr=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+          echo "dockerhub=benjisho/windows-mtr" >> "$GITHUB_OUTPUT"
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ steps.image.outputs.ghcr }}
+            ${{ steps.image.outputs.dockerhub }}
+          tags: |
+            type=raw,value=latest,enable=${{ inputs.publish_latest }}
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=semver,pattern={{version}},value=${{ github.ref_name }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=windows-mtr-release-docker
+          cache-to: type=gha,mode=max,scope=windows-mtr-release-docker
+          provenance: true
+          sbom: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,6 +76,17 @@ cargo test --test cli_tests
 cargo test --test report_tests
 ```
 
+
+## Workflow publish order (CI policy)
+
+Publishing to container registries is gated by workflow order:
+
+- `CI`, `CodeQL`, and `Security` must all succeed on `master` for the same commit SHA.
+- The gate workflow (`.github/workflows/publish-gate.yml`) then calls reusable publish logic in `.github/workflows/reusable-publish.yml`.
+- Tag releases continue through `release.yml`, which also reuses the same publish workflow before creating GitHub Releases.
+
+See `docs/WORKFLOW_ORDER_REVIEW.md` for the full policy summary.
+
 ## Project Layout
 
 - `src/` — core application code

--- a/docs/WORKFLOW_ORDER_REVIEW.md
+++ b/docs/WORKFLOW_ORDER_REVIEW.md
@@ -1,0 +1,26 @@
+# Workflow Order Review Policy
+
+This repository enforces publish ordering through a `workflow_run` gate.
+
+## Required workflow chain for `master`
+
+Container publication for `master` is allowed only after these workflows have completed successfully for the **same commit SHA**:
+
+1. `CI`
+2. `CodeQL`
+3. `Security`
+
+The gate is implemented in `.github/workflows/publish-gate.yml` and verifies workflow conclusions before invoking reusable publish logic.
+
+## Reusable publish logic
+
+To avoid duplicated release/publish code, image publishing is centralized in `.github/workflows/reusable-publish.yml` using `workflow_call`.
+
+- `publish-gate.yml` calls the reusable workflow for `master` publishes after required checks pass.
+- `release.yml` calls the same reusable workflow for tag-based releases before GitHub Release creation.
+
+## Tag release behavior
+
+`release.yml` now handles tag-based release flow (`v*.*.*`) and no longer publishes directly from branch pushes.
+
+This separation keeps release publication deterministic and makes policy review straightforward: checks first, then gated publish.


### PR DESCRIPTION
### Motivation

- Ensure container publication from `master` only occurs after required checks (`CI`, `CodeQL`, `Security`) have completed successfully for the same commit SHA.
- Avoid duplicated image-publish logic across workflows by centralizing publish steps into a reusable workflow.
- Make tag-based releases deterministic by restricting branch-based publishing and keeping release creation tied to tag pushes.

### Description

- Added `.github/workflows/publish-gate.yml` which listens to `workflow_run` events for `CI`, `CodeQL`, and `Security`, evaluates the latest runs for the commit SHA, and only proceeds to publish when all required workflows succeeded.
- Added `.github/workflows/reusable-publish.yml` as a `workflow_call` reusable workflow encapsulating Docker/GHCR login, metadata extraction, and `docker/build-push-action` steps, with an input `publish_latest` to control latest-tag behavior.
- Updated `.github/workflows/release.yml` to be tag-driven (`push` on `v*.*.*`) and to call the reusable publish workflow for tag releases instead of duplicating publish steps; branch publishes are no longer performed directly by this workflow.
- Documented the policy in `docs/WORKFLOW_ORDER_REVIEW.md` and added a short CI-policy note to `DEVELOPMENT.md` pointing contributors to the new gate and reusable publish workflow.

### Testing

- Parsed and validated all workflow YAML files locally using Ruby's YAML loader with the command `for f in .github/workflows/*.yml; do ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "ok #{ARGV[0]}"' "$f" || exit 1; done`, which succeeded for every workflow file.
- Attempted a Python/YAML validation (`python - <<'PY' import yaml ... PY`) but it failed in this environment because `PyYAML` is not installed, noted as an environment limitation.
- Performed basic sanity checks by loading/inspecting the modified workflows (no YAML syntax errors found) and ensured the reusable-publish invocation patterns align with the original publish steps to preserve previous behavior for tag releases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8809f83d483308564c2c5025aa30a)