### PR TITLE
Align concurrency controls across release-mutating workflows

### DIFF
--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -26,6 +26,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: release-mutation-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   docker-scout-compare:
     name: Build image and compare with production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-mutation-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -4,6 +4,10 @@ on:
   # Manually triggered from GitHub UI
   workflow_dispatch:
 
+concurrency:
+  group: release-mutation-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
### Motivation
- Ensure all workflows that can publish or mutate release/tag state share a single concurrency namespace per ref/tag so GitHub serializes mutation operations and avoids unsafe overlaps, while preserving release safety with `cancel-in-progress: false`.

### Description
- Changed the top-level `concurrency` group in `.github/workflows/release.yml` from `release-${{ github.ref }}` to `release-mutation-${{ github.ref }}` and kept `cancel-in-progress: false`.
- Added a top-level `concurrency` block to `.github/workflows/windows-build.yml` with `group: release-mutation-${{ github.ref }}` and `cancel-in-progress: false`.
- Added a top-level `concurrency` block to `.github/workflows/docker-scout.yml` with `group: release-mutation-${{ github.ref }}` and `cancel-in-progress: false`.

### Testing
- Verified the presence and values of `concurrency` stanzas across the three workflows using `rg -n '^concurrency:|^  group:|^  cancel-in-progress:'`, which reported the updated entries successfully.
- Inspected the resulting diffs with `git diff` to confirm the exact changes to `release.yml`, `windows-build.yml`, and `docker-scout.yml`, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a882071db883309395ac4ad990af83)