### PR TITLE
Limit Docker Scout PR triggers to image-affecting paths

### DIFF
--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -6,16 +6,18 @@ on:
     tags: ["v*"]
   pull_request:
     branches: ["**"]
-    # Skip docs-only PRs to reduce container CI cost and improve queue efficiency.
+    # Cost/latency optimization: only run when changes can affect Docker image build/output.
     paths:
       - Dockerfile
       - .dockerignore
       - Cargo.toml
       - Cargo.lock
+      - build.rs
       - src/**
-      - packaging/**
-      - scripts/**
+      - xtask/**
       - .github/workflows/docker-scout.yml
+      - .github/workflows/reusable-publish.yml
+      - .github/workflows/ci.yml
 
 env:
   REGISTRY: docker.io


### PR DESCRIPTION
### Motivation

- Reduce unnecessary Docker Scout CI runs by only triggering on changes that can affect the built image or build behavior. 
- Preserve faster feedback and lower cost/latency for PRs while retaining coverage for image-relevant changes and related workflows.

### Description

- Narrowed the `pull_request.paths` block in `.github/workflows/docker-scout.yml` and updated the inline comment to note this is a cost/latency optimization. 
- Added `build.rs` and `xtask/**` to the path filters, removed unrelated `packaging/**` and `scripts/**`, and included related workflow files `reusable-publish.yml` and `ci.yml` so changes that might affect image generation still trigger the job. 
- Left `Dockerfile`, `.dockerignore`, `Cargo.toml`, `Cargo.lock`, `src/**`, and the Docker Scout workflow itself in the path list to ensure build-relevant edits continue to run the comparison.

### Testing

- Verified the updated workflow file contents with `sed -n` and `nl -ba` to confirm the `pull_request.paths` block contains the intended entries; these inspections succeeded. 
- Reviewed `git diff` output to ensure only the intended path filters and comment were changed; the diff matched expectations. 
- No repository unit/integration tests were run because this change only scopes workflow triggers and does not modify runtime code or build artifacts; validations above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8930cef3083309d0df8f84cb5988a)