### PR TITLE
Harden workflow-run publish gate and document enforcement model

### DIFF
--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   evaluate-required-workflows:
     name: Evaluate required workflow results
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     outputs:
       should_publish: ${{ steps.evaluate.outputs.should_publish }}
@@ -55,6 +55,11 @@ jobs:
               const run = latestByName.get(workflowName);
               if (!run) {
                 missing.push(workflowName);
+                continue;
+              }
+
+              if (run.event !== "push" || run.head_branch !== "master") {
+                failed.push(`${workflowName} (unexpected trigger: event=${run.event}, branch=${run.head_branch})`);
                 continue;
               }
 

--- a/docs/WORKFLOW_ORDER_REVIEW.md
+++ b/docs/WORKFLOW_ORDER_REVIEW.md
@@ -24,3 +24,20 @@ To avoid duplicated release/publish code, image publishing is centralized in `.g
 `release.yml` now handles tag-based release flow (`v*.*.*`) and no longer publishes directly from branch pushes.
 
 This separation keeps release publication deterministic and makes policy review straightforward: checks first, then gated publish.
+
+## Recommendations
+
+Selected gating model: **`workflow_run` orchestration**.
+
+Enforcement point for maintainers:
+
+- Upstream required workflows are `CI`, `CodeQL`, and `Security`.
+- `.github/workflows/publish-gate.yml` is the explicit policy gate for branch publication and must remain enabled.
+- The gate only evaluates successful `push`-triggered runs on `master`, then verifies each required run for the same SHA is:
+  - present,
+  - completed,
+  - successful,
+  - and sourced from the expected `push`/`master` trigger context.
+- Only when all checks satisfy those conditions does the gate call `.github/workflows/reusable-publish.yml`.
+
+This means publish ordering is enforced in workflow orchestration (not branch protection rules): the publish workflow cannot proceed until required upstream workflows have already passed for the exact commit being published.


### PR DESCRIPTION
### Motivation

- Ensure publish ordering is deterministic by gating publication on successful upstream workflows for the exact commit SHA. 
- Prevent non-push or branch-mismatched workflow runs from satisfying the publish gate and accidentally triggering publishes. 
- Make the enforcement point explicit for maintainers so policy reviews and audits are straightforward.

### Description

- Tightened `.github/workflows/publish-gate.yml` so the gate only evaluates when the triggering upstream workflow was a successful `push` event by adding `github.event.workflow_run.event == 'push'` to the job `if` condition. 
- Added validation in the gate script to require each required workflow run (`CI`, `CodeQL`, `Security`) for the target SHA to be triggered by `push` on `master` (`run.event` and `run.head_branch` checks) before allowing publish. 
- Documented the selected gating model and enforcement details in `docs/WORKFLOW_ORDER_REVIEW.md` under a new `Recommendations` section and described the expected maintainers' enforcement point. 
- No application runtime code or dependency changes were made; this only tightens CI/workflow orchestration.

### Testing

- Ran `cargo fmt --all -- --check` which passed. 
- Attempted `cargo clippy --all-targets --all-features -- -D warnings` but it was blocked because the local `rustc` is `1.87.0` while the project and dependencies require `>=1.88.0`. 
- Attempted `cargo test --all` but it was blocked for the same local toolchain mismatch (`rustc 1.87.0` vs required `1.88.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a892eeedd48330b3a6b622153c7bd9)