### PR TITLE
Disable SARIF/database upload in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,3 +42,7 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+        with:
+          upload: never
+          upload-database: false
+          wait-for-processing: false


### PR DESCRIPTION
### Motivation
- Prevent CodeQL SARIF/database upload failures in PR runs when the repository default CodeQL setup is enabled, because GitHub rejects SARIF uploads from advanced configurations.

### Description
- Update `.github/workflows/codeql.yml` `analyze` step to set `upload: never`, `upload-database: false`, and `wait-for-processing: false` so analysis executes but no SARIF/database is submitted or awaited for processing.

### Testing
- Parsed the modified workflow YAML successfully with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codeql.yml'); puts 'YAML OK'"` and inspected the file to confirm the new keys are present.
- A Python YAML check was attempted but failed because the environment is missing the `yaml` module (`PyYAML`), which is an environment limitation and not a change regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9023db7a88330bbb6842cc627031a)