### PR TITLE
Align security workflow path filters for pull requests and pushes

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,23 +1,26 @@
 name: Security
 
 on:
+  # Path filters keep security checks focused on files that impact dependency risk,
+  # audit policy, or executable code paths; PR and push triggers intentionally match.
   workflow_dispatch:
   pull_request:
     branches: [ master ]
     paths:
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "deny.toml"
-      - "src/**"
-      - "xtask/**"
-      - ".github/workflows/security.yml"
-  push:
-    branches: [ master ]
-    paths:
+      - '.cargo/audit.toml'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'deny.toml'
+      - 'src/**'
+      - 'xtask/**'
+      - '.github/workflows/security.yml'
+  push:
+    branches: [ master ]
+    paths:
       - '.cargo/audit.toml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
       - 'src/**'
       - 'xtask/**'
       - '.github/workflows/security.yml'


### PR DESCRIPTION
### Motivation
- Ensure the security workflow runs for the same set of relevant repository changes for both PRs and pushes so dependency/audit/policy updates and executable code changes do not escape security checks.

### Description
- In `.github/workflows/security.yml` added `'.cargo/audit.toml'` to the `on.pull_request.paths` list, added a short comment above the `on:` triggers explaining why path filters exist, and reordered the `push.paths` list to exactly match `pull_request.paths` so both triggers are identical.

### Testing
- Verified the updated `security.yml` with automated checks: a YAML-based parse attempt failed due to the environment missing the `yaml` module, then a fallback line-parser script asserted that the `pull_request` and `push` `paths` lists are identical and contain `'.cargo/audit.toml'`, and the change was inspected with `git diff` and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9074e1cc483308fb94358447cdbe5)