### PR TITLE
CI: Require Windows stable PR job and demote Ubuntu/MSRV to secondary/full-validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1'
   push:
     branches: [ master ]
     paths-ignore:
@@ -68,6 +70,7 @@ jobs:
     name: Test (${{ matrix.os }}, msrv=${{ needs.resolve-msrv.outputs.msrv }})
     runs-on: ${{ matrix.os }}
     needs: resolve-msrv
+    if: github.event_name == 'push' || github.event_name == 'schedule'
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
@@ -112,15 +115,11 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
 
-  test-stable:
-    name: Test (${{ matrix.os }}, stable)
-    runs-on: ${{ matrix.os }}
+  test-windows-stable:
+    name: Test (windows-latest, stable)
+    runs-on: windows-latest
     needs: [resolve-msrv, test-msrv]
-    if: needs.resolve-msrv.outputs.run_stable == 'true'
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-      fail-fast: false
+    if: github.event_name == 'pull_request' || needs.resolve-msrv.outputs.run_stable == 'true'
 
     steps:
       - name: Checkout code
@@ -138,7 +137,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
-          shared-key: "rust-${{ matrix.os }}-stable"
+          shared-key: "rust-windows-latest-stable"
           cache-bin: true
           cache-directories: |
             ~/.cargo/registry/index
@@ -193,8 +192,8 @@ jobs:
   build-pr-binaries:
     name: Build PR Binaries
     runs-on: windows-latest
-    needs: [test-msrv, test-stable, docker-build-amd64]
-    if: github.event_name == 'pull_request' && needs.docker-build-amd64.result == 'success' && (needs.test-stable.result == 'success' || needs.test-stable.result == 'skipped')
+    needs: [test-windows-stable, test-ubuntu-smoke, docker-build-amd64]
+    if: github.event_name == 'pull_request' && needs.docker-build-amd64.result == 'success' && needs.test-windows-stable.result == 'success' && needs.test-ubuntu-smoke.result == 'success'
     permissions:
       contents: read
       issues: write
@@ -300,3 +299,77 @@ jobs:
               repo: context.repo.repo,
               body: comment
             });
+  test-ubuntu-smoke:
+    name: Test (ubuntu-latest, smoke)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: false
+          shared-key: "rust-ubuntu-latest-smoke"
+          cache-bin: true
+          cache-directories: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+          cache-on-failure: true
+
+      - name: Check (smoke)
+        run: cargo check --all-targets
+        env:
+          CARGO_INCREMENTAL: 0
+
+  test-ubuntu-stable-full:
+    name: Test (ubuntu-latest, stable-full)
+    runs-on: ubuntu-latest
+    needs: [resolve-msrv, test-msrv]
+    if: (github.event_name == 'push' || github.event_name == 'schedule') && needs.resolve-msrv.outputs.run_stable == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          shared-key: "rust-ubuntu-latest-stable"
+          cache-bin: true
+          cache-directories: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+          cache-on-failure: true
+
+      - name: Check
+        run: cargo check --all-targets
+        env:
+          CARGO_INCREMENTAL: 0
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+        env:
+          CARGO_INCREMENTAL: 0
+
+      - name: Run tests
+        run: cargo test --all
+        env:
+          CARGO_INCREMENTAL: 0


### PR DESCRIPTION
### Motivation
- Keep `resolve-msrv` and MSRV detection as the primary source of truth for toolchain gating. 
- Provide a focused, high-signal PR gate on Windows (`windows-latest`) to satisfy branch-protection needs while reducing PR latency. 
- Move heavier matrix and full Ubuntu/stable/MSRV validation off the PR path to `push`/scheduled runs to reduce CI cost. 

### Description
- Added a weekly `schedule` trigger and kept `workflow_dispatch` and `push`/`pull_request` triggers in the CI workflow. 
- Kept the `resolve-msrv` job intact and restricted `test-msrv` to run only on `push` or `schedule` via `if: github.event_name == 'push' || github.event_name == 'schedule'`. 
- Introduced a required PR-focused job `test-windows-stable` that runs on `windows-latest` and performs `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all`. 
- Converted the Ubuntu PR path into a lightweight `test-ubuntu-smoke` job that runs `cargo check --all-targets`, and moved the full Ubuntu stable validation into `test-ubuntu-stable-full` which runs on `push`/`schedule` only. 
- Updated `build-pr-binaries` dependencies to require `test-windows-stable`, `test-ubuntu-smoke`, and the Docker build job, and adjusted cache key names to reflect the new per-job caches. 
- Preserved the existing MSRV vs stable skip logic from `resolve-msrv`, and applied it only where full validations remain (push/schedule full-validation jobs). 

### Testing
- No full test suite was executed locally in this environment; changes are intended to be validated by GitHub Actions on PR and push events. 
- Attempted an automated YAML parse check using Python but it failed because `PyYAML` is not installed in the environment (error: `ModuleNotFoundError: No module named 'yaml'`).
- Confirmed the workflow file was updated in the repository and committed so CI will run the revised job graph on the next PR/push.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a907363d548330894074c5046b8c95)