### PR TITLE
Decouple stable CI job from MSRV test dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
   test-stable:
     name: Test (${{ matrix.os }}, stable)
     runs-on: ${{ matrix.os }}
-    needs: [resolve-msrv, test-msrv]
+    needs: [resolve-msrv]
     if: needs.resolve-msrv.outputs.run_stable == 'true'
     strategy:
       matrix:
@@ -194,7 +194,7 @@ jobs:
     name: Build PR Binaries
     runs-on: windows-latest
     needs: [test-msrv, test-stable, docker-build-amd64]
-    if: github.event_name == 'pull_request' && needs.docker-build-amd64.result == 'success' && (needs.test-stable.result == 'success' || needs.test-stable.result == 'skipped')
+    if: github.event_name == 'pull_request' && needs.docker-build-amd64.result == 'success' && needs.test-msrv.result == 'success' && (needs.test-stable.result == 'success' || needs.test-stable.result == 'skipped')
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
### Motivation
- Prevent `test-stable` from being unnecessarily blocked on `test-msrv` while preserving the existing stable-run gate `needs.resolve-msrv.outputs.run_stable`.
- Make downstream gating explicit so PR binary builds only proceed when the intended MSRV and docker checks pass.

### Description
- Updated `.github/workflows/ci.yml` so `test-stable` now depends only on `resolve-msrv` by changing `needs: [resolve-msrv, test-msrv]` to `needs: [resolve-msrv]`.
- Preserved the stable gate condition `if: needs.resolve-msrv.outputs.run_stable == 'true'` for conditional execution of the stable tests.
- Tightened the `build-pr-binaries` `if` condition to require `needs.test-msrv.result == 'success'` in addition to the docker success and allowing `test-stable` to be `success` or `skipped`.
- Ensured there are no implicit uses of `test-msrv` outputs/state elsewhere in the workflow.

### Testing
- Verified workflow edits with `rg -n "test-msrv|needs:" .github/workflows/ci.yml`, which completed successfully and showed updated dependency lines.
- Confirmed stable gate and output references with `rg -n "test-msrv\.outputs|needs\.test-msrv|run_stable" .github/workflows/ci.yml`, which returned the expected occurrences.
- Reviewed changes with `git diff -- .github/workflows/ci.yml` and `git status --short`, both of which completed successfully and reflected the intended modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a908a52434833094dd4921a4f93cc3)