### PR TITLE
Adjust CI job dependencies and gating for MSRV/stable tests and PR binary builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           fi
 
   test-msrv:
-    name: Test (${{ matrix.os }}, msrv=${{ needs.resolve-msrv.outputs.msrv }})
+    name: Test (${{ matrix.os }}, msrv)
     runs-on: ${{ matrix.os }}
     needs: resolve-msrv
     strategy:
@@ -115,7 +115,7 @@ jobs:
   test-stable:
     name: Test (${{ matrix.os }}, stable)
     runs-on: ${{ matrix.os }}
-    needs: [resolve-msrv, test-msrv]
+    needs: [resolve-msrv]
     if: needs.resolve-msrv.outputs.run_stable == 'true'
     strategy:
       matrix:
@@ -194,7 +194,7 @@ jobs:
     name: Build PR Binaries
     runs-on: windows-latest
     needs: [test-msrv, test-stable, docker-build-amd64]
-    if: github.event_name == 'pull_request' && needs.docker-build-amd64.result == 'success' && (needs.test-stable.result == 'success' || needs.test-stable.result == 'skipped')
+    if: github.event_name == 'pull_request' && needs.docker-build-amd64.result == 'success' && needs.test-msrv.result == 'success' && (needs.test-stable.result == 'success' || needs.test-stable.result == 'skipped')
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
### Motivation

- Allow the stable test matrix to start earlier (once MSRV is resolved) while keeping PR binary builds gated on MSRV success to avoid building from failing MSRV runs.
- Make the `test-msrv` job name simpler to avoid embedding an output expression in the display name.

### Description

- Changed the `test-msrv` job display name from `Test (${{ matrix.os }}, msrv=${{ needs.resolve-msrv.outputs.msrv }})` to `Test (${{ matrix.os }}, msrv)`.
- Removed `test-msrv` from the `needs` list of the `test-stable` job so `test-stable` now only needs `resolve-msrv` and is gated by `if: needs.resolve-msrv.outputs.run_stable == 'true'`.
- Tightened the `if` condition on the `build-pr-binaries` job to also require `needs.test-msrv.result == 'success'` in addition to the existing `docker-build-amd64` and `test-stable` checks.
- Left existing steps, caching configuration, and test commands unchanged.

### Testing

- No automated CI runs were executed as part of this change; the PR updates GitHub Actions workflow logic only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a908a52434833094dd4921a4f93cc3)