### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,6 +25,9 @@ on:
       - 'xtask/**'
       - '.github/workflows/security.yml'
 
+permissions:
+  contents: read
+
 jobs:
   cargo-security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/benjisho/windows-mtr/security/code-scanning/2](https://github.com/benjisho/windows-mtr/security/code-scanning/2)

To fix the problem, declare explicit, least-privilege `GITHUB_TOKEN` permissions for this workflow or for the `cargo-security` job. Since there is only one job and it just checks out code and runs local tools, it only needs read access to repository contents; the default minimal safe set is `contents: read`. No steps require writing to issues, PRs, packages, or other resources.

The best fix without changing functionality is to add a workflow-level `permissions:` block near the top of `.github/workflows/security.yml`, right after the `name:` (or before `jobs:`). This will apply to all jobs (currently just `cargo-security`). Concretely, in `.github/workflows/security.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and `jobs:` (or immediately after `name:` if you prefer; both are valid). No additional imports or actions are required, and no existing steps need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
