### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,6 +9,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/benjisho/windows-mtr/security/code-scanning/1](https://github.com/benjisho/windows-mtr/security/code-scanning/1)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions instead of relying on repository defaults. Since this workflow only needs to read the repository contents for checkout and to use artifacts, we can set `contents: read` for the build job. The `release` job already has `permissions: contents: write` and does not need changes.

The best fix with no functional change is to add a `permissions` block at the workflow root (applies to all jobs without their own `permissions`) or directly under the `build-windows` job. Because the `release` job already overrides permissions, using a root-level block is safe and clear: set `permissions: contents: read` at the top level, then keep the `release` job’s `contents: write`. Concretely, in `.github/workflows/windows-build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block. No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
