### PR TITLE
Harden CodeQL workflow permissions for non-upload mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
@@ -43,6 +42,7 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
+          # Non-uploading mode: run local analysis only and do not publish code-scanning alerts.
           upload: never
           upload-database: false
           wait-for-processing: false


### PR DESCRIPTION
### Motivation
- Align repository permissions with the configured CodeQL analyze mode by removing unnecessary write access for `security-events` when `github/codeql-action/analyze@v4` is running with uploads disabled (`upload: never`).

### Description
- Remove top-level `security-events: write` from `.github/workflows/codeql.yml` and add an inline YAML comment documenting that the `analyze` step intentionally runs in non-uploading mode while keeping `upload: never` and related options disabled.

### Testing
- Ran repository checks and file-inspection commands (`git diff -- .github/workflows/codeql.yml`, `nl -ba .github/workflows/codeql.yml | sed -n '1,220p'`, and `git diff --check HEAD~1..HEAD && git show --stat --oneline HEAD`) to verify the permission removal and that `upload: never` remains set; these commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab035360588330acec4896838cfb24)