### PR TITLE
Clarify BRANCH_REVIEW changed-file list and split completion vs follow-ups

### DIFF
--- a/docs/BRANCH_REVIEW.md
+++ b/docs/BRANCH_REVIEW.md
@@ -6,20 +6,28 @@ This document summarizes the current branch delta, what is complete, and what st
 The branch is focused on CI/CD maintenance (dependency updates in release automation), not runtime CLI or probe-engine behavior.
 
 ## What was introduced in this branch
-From branch history (`git log --oneline --name-only`):
+From branch history in the reviewed range (`git log --oneline --name-only`), the following files changed:
 
-1. `Bump docker/login-action from 3 to 4`
-   - Updated `docker/login-action` to `v4` in `.github/workflows/release.yml`.
-2. `Bump docker/setup-qemu-action from 3 to 4`
-   - Updated `docker/setup-qemu-action` to `v4` in `.github/workflows/release.yml`.
+1. `.github/workflows/release.yml`
+   - Bumped `docker/login-action` from major `v3` to `v4`.
+   - Bumped `docker/setup-qemu-action` from major `v3` to `v4`.
+2. `.github/workflows/security.yml`
+   - Added explicit workflow/job `permissions` to address least-privilege and code-scanning guidance.
+3. `.github/workflows/windows-build.yml`
+   - Added explicit workflow/job `permissions` to address least-privilege and code-scanning guidance.
+4. `README.md`
+   - Updated badge presentation/status messaging.
+   - Updated roadmap/status text to reflect current priorities.
 
-## Done vs still needed
+## 1) Completed in this PR
 
-### ✅ Done
 - Release workflow action versions were advanced to current major versions for Docker login and QEMU setup.
+- Security-sensitive workflows now include explicit `permissions` declarations (`security.yml` and `windows-build.yml`).
+- README documentation updates were included for badge and roadmap/status alignment.
 - Container publishing path still targets both GHCR and Docker Hub and keeps multi-arch build intent (`linux/amd64`, `linux/arm64`).
 
-### 🛠️ Still needed / recommended follow-ups
+## 2) Follow-up recommendations
+
 - Pin third-party actions to full commit SHAs (not only major tags) for stronger supply-chain immutability.
 - Keep least-privilege `permissions` review as part of recurring workflow maintenance.
 - Add/confirm CI checks that validate workflow changes before merge (e.g., actionlint in CI, if adopted by maintainers).


### PR DESCRIPTION
### Motivation

- Make the branch review explicit about which files were changed in the reviewed range to avoid ambiguity. 
- Prevent readers from interpreting follow-up recommendations as already implemented by splitting the previous combined section.

### Description

- Updated `docs/BRANCH_REVIEW.md` so **What was introduced in this branch** enumerates the changed files in the reviewed range, including ` .github/workflows/release.yml`, `.github/workflows/security.yml`, `.github/workflows/windows-build.yml`, and `README.md`.
- Documented the `release.yml` action bumps (bumped `docker/login-action` and `docker/setup-qemu-action` from v3→v4) and noted `permissions` additions in `security.yml` and `windows-build.yml` and badge/roadmap edits in `README.md`.
- Replaced the previous combined **Done vs still needed** section with two explicit sections: `1) Completed in this PR` and `2) Follow-up recommendations` to clearly separate implemented changes from suggested next steps.
- Kept existing note that container publishing still targets GHCR and Docker Hub with multi-arch intent (`linux/amd64`, `linux/arm64`).

### Testing

- Ran `git log --oneline --name-only -- docs/BRANCH_REVIEW.md .github/workflows/release.yml .github/workflows/security.yml .github/workflows/windows-build.yml README.md` to confirm the reviewed-file list and observed the expected entries (succeeded). 
- Inspected the change with `git diff -- docs/BRANCH_REVIEW.md` to validate the patch content and `nl -ba docs/BRANCH_REVIEW.md` to confirm the final file layout (succeeded). 
- Committed the update and created the PR record via the repository `make_pr` tool to publish the change (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0359ebec83309dadca07c239422b)