### PR TITLE
Pin workflow GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run_stable: ${{ steps.resolve.outputs.run_stable }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Resolve rust-version from Cargo.toml and stable toolchain version
         id: resolve
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust (MSRV)
         uses: dtolnay/rust-toolchain@stable
@@ -89,7 +89,7 @@ jobs:
 
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
           shared-key: "rust-${{ matrix.os }}-msrv-${{ needs.resolve-msrv.outputs.msrv }}"
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust (stable)
         uses: dtolnay/rust-toolchain@stable
@@ -138,7 +138,7 @@ jobs:
 
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
           shared-key: "rust-windows-latest-stable"
@@ -170,13 +170,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build Docker image (amd64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile
@@ -204,7 +204,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -215,7 +215,7 @@ jobs:
 
       # Use advanced caching
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: false # Only save cache for master branch builds
           # Restore from the trusted Windows stable cache populated on master.
@@ -273,7 +273,7 @@ jobs:
         shell: pwsh
       
       - name: Upload PR build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: windows-mtr-PR${{ github.event.pull_request.number }}
           path: |
@@ -283,7 +283,7 @@ jobs:
           
       - name: Comment on PR with download link
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -310,7 +310,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust (stable)
         uses: dtolnay/rust-toolchain@stable
@@ -318,7 +318,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: false
           shared-key: "rust-ubuntu-latest-smoke"
@@ -342,7 +342,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust (stable)
         uses: dtolnay/rust-toolchain@stable
@@ -352,7 +352,7 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
           shared-key: "rust-ubuntu-latest-stable"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,16 +31,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
         with:
           languages: rust
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
         with:
           # Non-uploading mode: run local analysis only and do not publish code-scanning alerts.
           upload: never

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
 
       # Use the more efficient Rust caching
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
           shared-key: "rust-windows-release"
@@ -193,23 +193,23 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -223,7 +223,7 @@ jobs:
 
       - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
             ${{ steps.image.outputs.ghcr }}
@@ -234,7 +234,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ github.ref_name }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./Dockerfile
@@ -260,7 +260,7 @@ jobs:
       contents: write  # Required for creating releases and uploading assets
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -271,7 +271,7 @@ jobs:
 
       # Use the more efficient Rust caching
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
           shared-key: "rust-windows-release"
@@ -427,7 +427,7 @@ jobs:
 
       # Upload all artifacts to GitHub
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: windows-mtr-release
           path: dist/windows-mtr-official.zip
@@ -437,7 +437,7 @@ jobs:
       # Create the GitHub release with only the official zip file
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: |
             dist/windows-mtr-official.zip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
   cargo-security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Rust 1.88.0
         uses: dtolnay/rust-toolchain@stable
@@ -40,7 +40,7 @@ jobs:
           toolchain: 1.88.0
 
       - name: Cache Cargo dependencies and installed binaries
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
           shared-key: "rust-security-1.88.0"
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run cargo-deny
         id: cargo_deny
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
         with:
           rust-version: 1.88.0
           command: check

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -28,7 +28,7 @@ jobs:
 
           
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           save-if: ${{ startsWith(github.ref, 'refs/tags/') }}
           shared-key: "rust-windows-build-release"
@@ -92,7 +92,7 @@ jobs:
           Pop-Location
       
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: windows-binaries
           path: |
@@ -110,14 +110,14 @@ jobs:
       contents: write  # Required for creating releases and uploading assets
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         
       - name: Display structure of downloaded files
         run: ls -R
         
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: |
             windows-binaries/windows-mtr.exe


### PR DESCRIPTION
### Motivation
- Harden GitHub Actions workflow supply-chain by replacing mutable tag references with immutable commit SHAs to reduce the risk of unexpected changes from upstream action tags.
- Preserve existing behavior and clarity by adding a trailing `# vN` comment so maintainers can see the human-readable tag that was pinned.

### Description
- Replaced `uses: owner/action@vN` with `uses: owner/action@<40-char-sha> # vN` across the workflows `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.github/workflows/security.yml`, `.github/workflows/windows-build.yml`, and `.github/workflows/codeql.yml`.
- Kept non-tag references (for example `@stable`, `@cargo-binstall`, or other non-`vN` refs) unchanged to avoid functional drift.
- Updated CodeQL action pins (`github/codeql-action/init` and `github/codeql-action/analyze`) and several commonly used actions such as `actions/checkout`, `docker/*`, `actions/upload-artifact`, `actions/download-artifact`, `softprops/action-gh-release`, and `EmbarkStudios/cargo-deny-action` to their resolved commit SHAs with inline tag comments.
- Left the Dependabot configuration intact and confirmed it is configured to track `github-actions` updates so SHA-pinned actions remain updateable by Dependabot.

### Testing
- Resolved upstream tag SHAs with a small script and verified the chosen SHAs correspond to the original tags by querying the remote repository tags using `git ls-remote`.
- Verified all modified workflow files contain no remaining `uses: ...@vN` patterns by running `rg -n "uses:" .github/workflows/*.yml` and `rg -n "uses: .*@v[0-9]+" .github/workflows/*.yml`.
- Performed a hygiene check with `git diff --check` to ensure there are no whitespace or patch issues and inspected diffs to confirm only `uses:` lines were changed.
- Confirmed `.github/dependabot.yml` includes `package-ecosystem: "github-actions"` on a weekly schedule so Dependabot can continue updating pinned action SHAs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab034ad240833099738fc0b16ffa67)