### PR TITLE
Add Workflow QA actionlint check, pre-commit hook, and CONTRIBUTING docs update

### DIFF
--- a/.github/workflows/workflow-qa.yml
+++ b/.github/workflows/workflow-qa.yml
@@ -18,4 +18,4 @@ jobs:
           fetch-depth: 1
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: docker://rhysd/actionlint:1.7.11

--- a/.github/workflows/workflow-qa.yml
+++ b/.github/workflows/workflow-qa.yml
@@ -1,0 +1,21 @@
+name: Workflow QA
+
+on:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.11
+    hooks:
+      - id: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,13 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.11
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,13 @@ repos:
       - id: trailing-whitespace
       - id: check-added-large-files
 
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+      - id: cargo-check
+      - id: clippy
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.11
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,8 @@ To mirror CI locally, install [pre-commit](https://pre-commit.com/) and run:
 pre-commit run --all-files
 ```
 
+The repository pre-commit configuration includes workflow QA and baseline hygiene checks such as `check-merge-conflict`, `check-yaml`, trailing whitespace, and end-of-file normalization.
+
 If you only want to run workflow QA directly, run:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,20 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo test --all
 ```
 
+All pull requests run a dedicated **Workflow QA** check with `actionlint` to validate GitHub Actions workflow syntax and semantics.
+
+To mirror CI locally, install [pre-commit](https://pre-commit.com/) and run:
+
+```bash
+pre-commit run --all-files
+```
+
+If you only want to run workflow QA directly, run:
+
+```bash
+actionlint
+```
+
 If any command cannot run in your environment, include:
 
 - The exact command

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ To mirror CI locally, install [pre-commit](https://pre-commit.com/) and run:
 pre-commit run --all-files
 ```
 
-The repository pre-commit configuration includes workflow QA and baseline hygiene checks such as `check-merge-conflict`, `check-yaml`, trailing whitespace, and end-of-file normalization.
+The repository pre-commit configuration includes workflow QA, baseline hygiene checks (such as `check-merge-conflict`, `check-yaml`, trailing whitespace, and end-of-file normalization), and Rust checks (`cargo fmt`, `cargo check`, and `cargo clippy`).
 
 If you only want to run workflow QA directly, run:
 


### PR DESCRIPTION
### Motivation
- Add automated validation of GitHub Actions workflows to catch syntax and semantic problems early and make it easy for contributors to run the same checks locally.

### Description
- Add `.github/workflows/workflow-qa.yml` with a `actionlint` job that runs `rhysd/actionlint@v1` on `pull_request` events against `master`.
- Add `.pre-commit-config.yaml` to register the `actionlint` hook at `v1.7.11` so contributors can run the workflow linter locally via `pre-commit`.
- Update `CONTRIBUTING.md` to document the new Workflow QA check and to show commands to run `pre-commit run --all-files` and `actionlint` locally.

### Testing
- No automated tests were executed as part of this change; CI will run the new `Workflow QA` job which executes `actionlint` on pull requests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0381f8288330b552e1a975da2af6)