### PR TITLE
Add check-toml to pre-commit hygiene hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
+      - id: check-toml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-added-large-files


### PR DESCRIPTION
### Motivation
- Ensure TOML files (including Cargo and tooling configs) are validated early in the lightweight hygiene stage so issues are caught before expensive Rust hooks run.

### Description
- Add `- id: check-toml` to the `pre-commit/pre-commit-hooks` hooks in `.pre-commit-config.yaml`, placed directly after `check-yaml` and alongside merge-conflict checks, with no custom excludes.

### Testing
- Attempted `pre-commit run check-toml --all-files` but `pre-commit` is not installed in this environment, so validation was limited to reviewing the config diff and committing the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2e8e5c5c83309961cc6978d962fe)