### PR TITLE
Configure Rust pre-commit hooks for workspace-level enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,17 @@ repos:
     rev: v1.0
     hooks:
       - id: fmt
+        name: rust: cargo fmt --all -- --check
+        args: [--all, --, --check]
+        pass_filenames: false
       - id: cargo-check
+        name: rust: cargo check --workspace
+        args: [--workspace]
+        pass_filenames: false
       - id: clippy
+        name: rust: cargo clippy --all-targets --all-features -- -D warnings
+        args: [--all-targets, --all-features, --, -D, warnings]
+        pass_filenames: false
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.11


### PR DESCRIPTION
### Motivation
- Enforce workspace-wide formatting, linting, and checks for Rust so pre-commit behavior matches the project's documented `cargo` commands and surfaces issues consistently at commit time.

### Description
- Update `.pre-commit-config.yaml` for the `doublify/pre-commit-rust` hooks by adding explicit `name` labels and workspace-scoped `args`: set `fmt` to `rust: cargo fmt --all -- --check` with `args: [--all, --, --check]`, set `cargo-check` to `rust: cargo check --workspace` with `args: [--workspace]`, set `clippy` to `rust: cargo clippy --all-targets --all-features -- -D warnings` with `args: [--all-targets, --all-features, --, -D, warnings]`, and set `pass_filenames: false` for all three hooks so they run coherently at crate/workspace scope.

### Testing
- Ran `cargo fmt --all -- --check` (passed), `cargo clippy --all-targets --all-features -- -D warnings` (failed due to toolchain mismatch: environment `rustc 1.87.0` vs project requires `rustc 1.88.0`), `cargo test --all` (failed for the same reason), and attempted `pre-commit run --all-files` (could not run because `pre-commit` is not installed in the environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2e90bdd8833084c17d6eb3dc2e32)