### PR TITLE
Add markdownlint pre-commit hook and baseline config

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
     rev: v1.7.11
     hooks:
       - id: actionlint
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+      - id: markdownlint


### PR DESCRIPTION
### Motivation
- Introduce lightweight, lint-first markdown checks to improve documentation quality without adding an auto-formatter that could conflict with the repository's existing doc style.

### Description
- Added the `igorshubovych/markdownlint-cli` `markdownlint` hook to `.pre-commit-config.yaml` and created a `.markdownlint.json` baseline that enables defaults while disabling `MD013` and `MD033` to tolerate long lines and inline HTML used in the docs.

### Testing
- Attempted to run `pre-commit validate-config && pre-commit run markdownlint --all-files` but `pre-commit` is not installed in the environment, and I validated the new files by loading `.markdownlint.json` with `python` and parsing `.pre-commit-config.yaml` with `ruby`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2e93a5f88330970e6d778acd440f)