### PR TITLE
Add hadolint pre-commit hook scoped to Dockerfiles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,9 @@ repos:
     rev: v1.7.11
     hooks:
       - id: actionlint
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+        files: '^Dockerfile.*$|\\.dockerfile$'


### PR DESCRIPTION
### Motivation
- Enforce Dockerfile linting in local and CI pre-commit workflows to catch Dockerfile issues early. 
- Keep hook runtime fast by limiting execution to files that match repository Dockerfile naming patterns.

### Description
- Added the `hadolint` pre-commit repository `https://github.com/hadolint/hadolint` pinned to `v2.12.0` in `.pre-commit-config.yaml`.
- Added the `hadolint` hook and scoped it with `files: '^Dockerfile.*$|\\.dockerfile$'` so it runs only for Dockerfile targets in this repo.
- Did not disable any hadolint rules; any intentional rule violations should be handled with inline ignores or a focused hadolint config file instead of disabling the hook.

### Testing
- Confirmed there is a `Dockerfile` present in the repo using a file search (`rg`).
- Attempted `pre-commit validate-config`, which could not run because `pre-commit` is not installed in this environment. 
- Ran `git diff --check` to ensure the patch has no whitespace/formatting issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2e8c0a688330b0ec2c3bfc9c8ed0)