### PR TITLE
Fix README fenced code spacing for MD031 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ For email server connectivity:
 ```bash
 mtr -T -P 25 mailserver.example.com
 ```
+
 </details>
 
 <details>
@@ -292,6 +293,7 @@ For enterprise environments, use our logging features to send results to central
 ```bash
 mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://logging.example.com/api/v1/logs
 ```
+
 </details>
 
 ## 📋 Documentation


### PR DESCRIPTION
### Motivation
- Address Markdownlint rule MD031 by ensuring fenced code blocks are surrounded by blank lines to avoid false positives in HTML/details-adjacent fences.
- This is a documentation-only change with no runtime or CLI behavior impact.

### Description
- Inserted a blank line after two fenced code blocks in `README.md` so each fence is separated from the subsequent `</details>` tag.
- Changes are limited to `README.md` and preserve existing wording and examples.

### Testing
- Ran `pre-commit run markdownlint --files README.md` which failed initially because `pre-commit` was not installed in the environment.
- Installed `pre-commit` with `python3 -m pip install pre-commit` and re-ran `pre-commit run markdownlint --files README.md`, which failed before linting due to a `.pre-commit-config.yaml` parse error (`mapping values are not allowed in this context` at line 16), so markdownlint could not be executed to confirm the rule pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf096907c83308eb1dc5dcce43683)