### PR TITLE
Add tiered markdownlint policy and document workflow in CONTRIBUTING.md

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,11 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD022": false,
+  "MD024": false,
+  "MD031": false,
+  "MD032": false,
+  "MD033": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,28 @@ pre-commit run --all-files
 
 The repository pre-commit configuration includes workflow QA, baseline hygiene checks (such as `check-merge-conflict`, `check-yaml`, trailing whitespace, and end-of-file normalization), and Rust checks (`cargo fmt`, `cargo check`, and `cargo clippy`).
 
+Markdown linting uses a **two-tier policy**:
+
+1. **Baseline full-repository lint must pass** using the repository's relaxed legacy profile in `.markdownlint.jsonc`.
+2. **Any Markdown file changed in your branch must pass strict lint** using `strict.markdownlint.jsonc`.
+
+Run the baseline check:
+
+```bash
+npx -y markdownlint-cli2 "**/*.md" "!target/**" "!vendor/**"
+```
+
+Run strict lint for Markdown files changed from `master`:
+
+```bash
+changed_md_files=$(git diff --name-only --diff-filter=ACMR origin/master...HEAD -- '*.md')
+if [ -n "$changed_md_files" ]; then
+  printf '%s\n' "$changed_md_files" | xargs -r npx -y markdownlint-cli2 --config strict.markdownlint.jsonc
+fi
+```
+
+This approach keeps legacy documentation debt scoped while ensuring newly touched Markdown meets stricter standards.
+
 If you only want to run workflow QA directly, run:
 
 ```bash

--- a/strict.markdownlint.jsonc
+++ b/strict.markdownlint.jsonc
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "MD013": false
+}


### PR DESCRIPTION
### Motivation
- The repository has a large markdownlint backlog that blocks full-repo strict enforcement, so a scoped approach was chosen to make progress safe and incremental. 
- Adopt a two-tier policy to keep a relaxed baseline for legacy files while enforcing stricter rules on newly changed Markdown.

### Description
- Add a relaxed baseline config in `.markdownlint.jsonc` to accept existing legacy patterns while keeping most rules enabled. 
- Add a strict config in `strict.markdownlint.jsonc` to be used for files changed in a branch (stricter defaults, only `MD013`/line-length disabled). 
- Document the new two-tier workflow in `CONTRIBUTING.md`, including the exact commands to run the baseline full-repo check and the strict changed-file check. 
- This change is docs/config only and does not modify runtime/CLI behavior.

### Testing
- Ran the baseline lint: `npx -y markdownlint-cli2 "**/*.md" "!target/**" "!vendor/**"`, which completed with no errors. 
- Validated strict lint against the modified files with `npx -y markdownlint-cli2 --config strict.markdownlint.jsonc CONTRIBUTING.md .markdownlint.jsonc strict.markdownlint.jsonc`, which completed with no errors. 
- No code tests were required because this is a documentation and lint-config change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf09193388330a9fae25cbcb801eb)