### PR TITLE
Fix actionlint and hadolint failures in CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,11 @@ jobs:
             run_stable=true
           fi
 
-          echo "msrv=$msrv" >> "$GITHUB_OUTPUT"
-          echo "stable_version=$stable_version" >> "$GITHUB_OUTPUT"
-          echo "run_stable=$run_stable" >> "$GITHUB_OUTPUT"
+          {
+            echo "msrv=$msrv"
+            echo "stable_version=$stable_version"
+            echo "run_stable=$run_stable"
+          } >> "$GITHUB_OUTPUT"
 
           if [ "$run_stable" = "false" ]; then
             echo "Stable toolchain ($stable_version) matches MSRV ($msrv). Skipping CI / Test (..., stable) because CI / Test (..., msrv=$msrv) already validated this version." >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM debian:trixie-slim AS runtime
 
+# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Motivation
- Address linter failures surfaced by CI (`actionlint`/shellcheck and `hadolint`) to make pre-commit / workflow checks green while keeping runtime behavior unchanged.

### Description
- Grouped the three `$GITHUB_OUTPUT` writes into a single redirected block in the `resolve-msrv` step of `.github/workflows/ci.yml` to avoid `SC2129`/`actionlint` warnings.
- Added a targeted hadolint suppression comment (`# hadolint ignore=DL3008`) above the runtime `apt-get install` line in `Dockerfile` to document the intentional unpinned runtime package install approach.

### Testing
- Attempted `pre-commit run --all-files`, but the `pre-commit` command was not available in the environment so that check could not be executed here (failed: `bash: command not found: pre-commit`).
- Running `cargo` with the local default toolchain failed due to an older Rust toolchain (rustc 1.87.0) incompatible with project dependencies. 
- Installed `rustfmt` and `clippy` for the stable toolchain and ran `cargo +stable fmt --all -- --check`, `cargo +stable clippy --all-targets --all-features -- -D warnings`, and `cargo +stable test --all`, and these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe3e3e9bc8330b0fdc3456878a4ff)