### PR TITLE
Guard trippy Test-Path checks against null in Windows workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
           )
           $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
 
-          if (Test-Path $trippyPath) {
+          if ($trippyPath -and (Test-Path -Path $trippyPath)) {
             echo "Trippy executable found at: $trippyPath"
             echo "TRIPPY_PATH=$trippyPath" >> $env:GITHUB_ENV
           } else {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           )
           $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
 
-          if (Test-Path $trippyPath) {
+          if ($trippyPath -and (Test-Path -Path $trippyPath)) {
             echo "Trippy executable found at: $trippyPath"
             echo "TRIPPY_PATH=$trippyPath" >> $env:GITHUB_ENV
           } else {
@@ -189,7 +189,7 @@ jobs:
             $trippyPath = $env:TRIPPY_PATH
           }
 
-          if (Test-Path $trippyPath) {
+          if ($trippyPath -and (Test-Path -Path $trippyPath)) {
             echo "Found trippy at: $trippyPath"
             echo "TRIPPY_PATH=$trippyPath" >> $env:GITHUB_ENV
           } else {
@@ -330,7 +330,7 @@ jobs:
           )
           $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
 
-          if (Test-Path $trippyPath) {
+          if ($trippyPath -and (Test-Path -Path $trippyPath)) {
             echo "Trippy executable found at: $trippyPath"
             echo "TRIPPY_PATH=$trippyPath" >> $env:GITHUB_ENV
           } else {
@@ -358,7 +358,7 @@ jobs:
             $trippyPath = $env:TRIPPY_PATH
           }
 
-          if (Test-Path $trippyPath) {
+          if ($trippyPath -and (Test-Path -Path $trippyPath)) {
             echo "Found trippy at: $trippyPath"
             echo "TRIPPY_PATH=$trippyPath" >> $env:GITHUB_ENV
           } else {


### PR DESCRIPTION
### Motivation
- Prevent GitHub Actions PowerShell jobs from throwing `Value cannot be null` when `$trippyPath` is unresolved by ensuring `Test-Path` is only called on non-null paths.

### Description
- Updated Windows workflow scripts to add a null/empty guard before `Test-Path` in the trippy install/find blocks by replacing `if (Test-Path $trippyPath)` with `if ($trippyPath -and (Test-Path -Path $trippyPath))` in `.github/workflows/release.yml` and `.github/workflows/ci.yml`.

### Testing
- Ran `cargo fmt --all -- --check` which succeeded; `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test --all` were attempted but failed in this environment due to the installed `rustc` being 1.87.0 while the project and dependencies require Rust 1.88.0+.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30bc5072483309edff70496b97977)