### PR TITLE
CI(release): force-install `trippy` (`trip`) and simplify executable detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,13 @@ jobs:
         run: |
           echo "Installing trippy..."
 
-          # Prefer prebuilt binaries for speed and reliability.
-          # Fallback to a source build only when a prebuilt artifact is unavailable
-          # (for example, temporary upstream gaps for a target/version combination).
-          cargo binstall trippy --no-confirm --locked
+          # In CI, force installation to avoid stale "already installed" state
+          # and install only the expected Trippy binary (`trip`).
+          cargo binstall trippy --no-confirm --locked --force --bin trip
 
           if ($LASTEXITCODE -ne 0) {
             Write-Warning "cargo binstall could not fetch a prebuilt trippy binary; falling back to cargo install from source."
-            cargo install trippy --locked
+            cargo install trippy --locked --force --bin trip
             if ($LASTEXITCODE -ne 0) {
               Write-Error "Failed to install trippy via both cargo binstall and cargo install fallback."
               exit 1
@@ -79,9 +78,7 @@ jobs:
           $cargoBin = if ($env:CARGO_HOME) { Join-Path $env:CARGO_HOME "bin" } else { Join-Path $env:USERPROFILE ".cargo\bin" }
           $candidatePaths = @(
             (Join-Path $cargoBin "trip.exe"),
-            (Join-Path $cargoBin "trippy.exe"),
-            (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue),
-            (Get-Command trippy -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue)
+            (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path -ErrorAction SilentlyContinue)
           )
           $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
 
@@ -180,9 +177,7 @@ jobs:
             $cargoBin = if ($env:CARGO_HOME) { Join-Path $env:CARGO_HOME "bin" } else { Join-Path $env:USERPROFILE ".cargo\bin" }
             $candidatePaths = @(
               (Join-Path $cargoBin "trip.exe"),
-              (Join-Path $cargoBin "trippy.exe"),
-              (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue),
-              (Get-Command trippy -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue)
+              (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path -ErrorAction SilentlyContinue)
             )
             $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
           } else {
@@ -308,13 +303,13 @@ jobs:
           echo "Installing trippy..."
 
           # Prefer prebuilt binaries for speed and reliability.
-          # Fallback to a source build only when a prebuilt artifact is unavailable
-          # (for example, temporary upstream gaps for a target/version combination).
-          cargo binstall trippy --no-confirm --locked
+          # In CI, force install the expected Trippy binary (`trip`) to avoid
+          # stale metadata that can report "already installed" without a usable executable.
+          cargo binstall trippy --no-confirm --locked --force --bin trip
 
           if ($LASTEXITCODE -ne 0) {
             Write-Warning "cargo binstall could not fetch a prebuilt trippy binary; falling back to cargo install from source."
-            cargo install trippy --locked
+            cargo install trippy --locked --force --bin trip
             if ($LASTEXITCODE -ne 0) {
               Write-Error "Failed to install trippy via both cargo binstall and cargo install fallback."
               exit 1
@@ -324,9 +319,7 @@ jobs:
           $cargoBin = if ($env:CARGO_HOME) { Join-Path $env:CARGO_HOME "bin" } else { Join-Path $env:USERPROFILE ".cargo\bin" }
           $candidatePaths = @(
             (Join-Path $cargoBin "trip.exe"),
-            (Join-Path $cargoBin "trippy.exe"),
-            (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue),
-            (Get-Command trippy -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue)
+            (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path -ErrorAction SilentlyContinue)
           )
           $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
 
@@ -349,9 +342,7 @@ jobs:
             $cargoBin = if ($env:CARGO_HOME) { Join-Path $env:CARGO_HOME "bin" } else { Join-Path $env:USERPROFILE ".cargo\bin" }
             $candidatePaths = @(
               (Join-Path $cargoBin "trip.exe"),
-              (Join-Path $cargoBin "trippy.exe"),
-              (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue),
-              (Get-Command trippy -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue)
+              (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path -ErrorAction SilentlyContinue)
             )
             $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
           } else {


### PR DESCRIPTION
### Motivation

- Prevent CI from treating a stale local installation as valid by forcing installation of the expected `trip` binary.
- Simplify and harden detection of the installed trippy executable to avoid checking for obsolete names or failing to read command paths.

### Description

- Add `--force --bin trip` to `cargo binstall` and to the `cargo install` fallback in both `build` and `publish-package` jobs to ensure a fresh, predictable `trip` binary is installed.
- Remove references to `trippy.exe` as a candidate and only check for `trip.exe` plus `Get-Command` results, using `Path` instead of `Source` when resolving command locations.
- Update inline comments to explain the forced install rationale and the focused binary selection.
- Apply the same installation and discovery changes to both the bundling step and the initial install step so both build and publish workflows behave consistently.

### Testing

- Ran `cargo check --all-targets` in CI and it completed successfully.
- Ran `cargo test --all` in CI and all tests passed.
- Executable verification steps in the workflow (version output and basic CLI parsing) ran and succeeded in the CI run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3467332fc833087855a253dc8737b)