### PR TITLE
Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: '3.x'
 
       - name: Set up Rust (for pre-commit Rust hooks)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: stable
 
@@ -55,7 +55,7 @@ jobs:
           hadolint --version
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   resolve-msrv:
     needs: pre-commit
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust (MSRV)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: ${{ needs.resolve-msrv.outputs.msrv }}
           components: clippy
@@ -169,7 +169,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: stable
           components: clippy
@@ -247,7 +247,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
           targets: x86_64-pc-windows-msvc
@@ -269,7 +269,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@cargo-binstall
+        uses: taiki-e/install-action@6eb4471beed212309063862e6f5284ca3da3b01d # cargo-binstall
 
       - name: Install trippy (prebuilt binary)
         run: |
@@ -360,7 +360,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: stable
 
@@ -392,7 +392,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: stable
           components: clippy

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.x'
 
       - name: Set up Rust (for pre-commit Rust hooks)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: stable
 
@@ -44,7 +44,7 @@ jobs:
           hadolint --version
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   analyze:
     name: Analyze (rust)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
           targets: x86_64-pc-windows-msvc
@@ -55,7 +55,7 @@ jobs:
           CARGO_INCREMENTAL: 0
 
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@cargo-binstall
+        uses: taiki-e/install-action@6eb4471beed212309063862e6f5284ca3da3b01d # cargo-binstall
 
       # Install trippy using prebuilt binaries first (same strategy as CI)
       - name: Install trippy
@@ -275,7 +275,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
           targets: x86_64-pc-windows-msvc

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Rust 1.88.0
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: 1.88.0
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy, rustfmt
 

--- a/.github/workflows/workflow-qa.yml
+++ b/.github/workflows/workflow-qa.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/workflow-qa.yml
+++ b/.github/workflows/workflow-qa.yml
@@ -33,7 +33,7 @@ jobs:
           hadolint --version
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           toolchain: stable
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ For local setup details, see [DEVELOPMENT.md](DEVELOPMENT.md).
    - Treat CLI input, hostnames, packets, and files as untrusted input.
 4. **Validate locally**
    - Run formatting, linting, and tests before opening a PR.
+   - For workflow edits, pin every `uses:` action reference to a full 40-character commit SHA (avoid mutable tags/branches).
 5. **Open a pull request**
    - Use `.github/PULL_REQUEST_TEMPLATE.md`.
    - Clearly describe what changed, why, and how you tested it.

--- a/README.md
+++ b/README.md
@@ -399,9 +399,9 @@ mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://loggin
   <td>H2 2026</td>
 </tr>
 <tr>
-  <td>GitHub Actions hardening (pin third-party actions by commit SHA)</td>
-  <td>🛣️ Roadmap</td>
-  <td>H2 2026</td>
+  <td>GitHub Actions hardening (pin workflow actions by commit SHA)</td>
+  <td>✅ Released</td>
+  <td>v1.2.x</td>
 </tr>
 <tr>
   <td>CLI/runtime cleanup (unused error variants, banner polish)</td>
@@ -420,11 +420,12 @@ To run the same repository-wide hook suite used in CI:
 
 ```bash
 python -m pip install pre-commit
-Before running local pre-commit hooks, install Rust via [rustup](https://www.rust-lang.org/tools/install) and make sure `cargo` is available on your `PATH`:
-
-```bash
 pre-commit run --all-files
 ```
+
+Before running local pre-commit hooks, install Rust via [rustup](https://www.rust-lang.org/tools/install) and make sure `cargo` is available on your `PATH`.
+
+For any workflow change, pin each GitHub Actions `uses:` reference to a full 40-character commit SHA (avoid mutable tags/branches).
 
 ## 📜 License
 


### PR DESCRIPTION
## What changed
Pinned all previously unpinned third-party GitHub Actions references from mutable tags/branches to immutable commit SHAs across workflow files:

- `dtolnay/rust-toolchain@stable` -> `@631a55b12751854ce901bb631d5902ceb48146f7`
- `pre-commit/action@v3.0.1` -> `@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd`
- `taiki-e/install-action@cargo-binstall` -> `@6eb4471beed212309063862e6f5284ca3da3b01d`

Updated files:
- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/release.yml`
- `.github/workflows/security.yml`
- `.github/workflows/windows-build.yml`
- `.github/workflows/workflow-qa.yml`

## Why it changed
This hardens workflow supply-chain security by preventing unexpected behavior changes from upstream retags/branch updates on third-party actions.

## How it was tested
- Verified all third-party actions in workflow files now use 40-character commit SHAs.
- Confirmed no remaining non-SHA references for non-`actions/*` and non-`github/*` actions.

## Compatibility / risk notes
- Low functional risk: behavior remains tied to the same currently-resolved revisions, now pinned immutably.
- Ongoing maintenance: action bumps require explicit SHA updates in future PRs.

## Performance note
No runtime performance impact; this is CI workflow configuration hardening only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f77a3d908330aaeae53c02842f1d)