### PR TITLE
Add regression smoke assertions for privilege diagnostics contract

### DIFF
--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::{fs, path::Path};
 
 #[test]
 fn test_help_output() {
@@ -64,6 +65,41 @@ fn test_enhanced_wrapper_conflicts_with_passthrough_override() {
     let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
     assert!(
         stderr.contains("--trippy-flags cannot override windows-mtr enhanced UI wrapper settings")
+    );
+}
+
+#[test]
+fn test_insufficient_privileges_diagnostic_contract_is_stable() {
+    let error_rs = fs::read_to_string(Path::new("src/error.rs"))
+        .expect("should be able to read src/error.rs for contract assertions");
+
+    assert!(
+        error_rs.contains("InsufficientPrivileges"),
+        "Expected explicit InsufficientPrivileges error category to remain present",
+    );
+    assert!(
+        error_rs.contains("Administrator privileges are required to run traceroute"),
+        "Expected insufficient privilege diagnostics to keep user-readable summary",
+    );
+    assert!(
+        error_rs.contains("Run as administrator"),
+        "Expected insufficient privilege diagnostics to include actionable guidance",
+    );
+}
+
+#[test]
+fn test_icmp_path_does_not_silently_fallback_to_tcp_or_udp() {
+    let main_rs = fs::read_to_string(Path::new("src/main.rs"))
+        .expect("should be able to read src/main.rs for transport guardrail assertions");
+
+    assert!(
+        main_rs.contains("if args.tcp {") && main_rs.contains("} else if args.udp {"),
+        "Expected transport selection to remain explicit and mutually-exclusive",
+    );
+    assert!(
+        main_rs.contains("trippy_args.push(\"--tcp\".to_string());")
+            && main_rs.contains("trippy_args.push(\"--udp\".to_string());"),
+        "Expected TCP/UDP probes to be opt-in only",
     );
 }
 


### PR DESCRIPTION
### Motivation
- Prevent regressions that could weaken or change the user-facing insufficient-privilege guidance and to ensure probe-mode behavior does not silently change during refactors.

### Description
- Add two regression smoke tests in `tests/cli_tests.rs`: one that asserts `src/error.rs` continues to expose the `InsufficientPrivileges` identifier and user-facing guidance strings (`"Administrator privileges are required to run traceroute"` and `"Run as administrator"`), and another that asserts `src/main.rs` keeps explicit transport selection (`if args.tcp { } else if args.udp { }`) and explicit `trippy_args.push("--tcp".to_string())` / `trippy_args.push("--udp".to_string())` behavior so ICMP is not silently replaced by TCP/UDP.

### Testing
- Ran `cargo fmt --all -- --check` which succeeded.
- Attempted `cargo clippy --all-targets --all-features -- -D warnings` but it was blocked by a toolchain mismatch (`rustc 1.87.0` installed vs project requires `1.88.0`).
- Attempted `cargo test --all` but it was likewise blocked by the same Rust toolchain mismatch (`rustc 1.87.0` vs required `1.88.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f9627ae08330b440366db3b282d1)