### PR TITLE
Add privilege-sensitive probe smoke CI lanes and integration harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      run_windows_elevated_self_hosted:
+        description: "Run privileged Windows probe smoke on an elevated self-hosted runner"
+        required: false
+        default: false
+        type: boolean
   schedule:
     - cron: '0 5 * * 1'
   push:
@@ -424,3 +430,120 @@ jobs:
         run: cargo test --all
         env:
           CARGO_INCREMENTAL: 0
+
+  privilege-probe-smoke:
+    name: Privilege probe smoke (${{ matrix.os }}, non-elevated)
+    runs-on: ${{ matrix.os }}
+    needs: pre-commit
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            expected_stderr_any_of: "privileges are required"
+          - os: windows-latest
+            expected_stderr_any_of: "Administrator privileges are required to run traceroute||A required privilege is not held by the client||Permission denied"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          save-if: false
+          shared-key: "rust-${{ matrix.os }}-probe-smoke"
+          cache-bin: true
+          cache-directories: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+          cache-on-failure: true
+
+      - name: Run non-elevated privilege smoke harness
+        run: cargo test --test privilege_probe_smoke -- --exact privilege_probe_smoke --nocapture
+        env:
+          CARGO_INCREMENTAL: 0
+          EXPECT_EXIT_CODE: "1"
+          EXPECT_STDERR_ANY_OF: ${{ matrix.expected_stderr_any_of }}
+
+  privilege-probe-smoke-linux-privileged:
+    name: Privilege probe smoke (ubuntu-latest, elevated)
+    runs-on: ubuntu-latest
+    needs: pre-commit
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          save-if: false
+          shared-key: "rust-ubuntu-latest-probe-smoke-elevated"
+          cache-bin: true
+          cache-directories: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+          cache-on-failure: true
+
+      - name: Build smoke harness without running
+        run: cargo test --test privilege_probe_smoke --no-run
+        env:
+          CARGO_INCREMENTAL: 0
+
+      - name: Run elevated privilege smoke harness
+        shell: bash
+        run: |
+          test_bin=$(find target/debug/deps -maxdepth 1 -type f -name 'privilege_probe_smoke-*' -executable | head -n 1)
+          if [ -z "$test_bin" ]; then
+            echo "Unable to locate compiled privilege smoke harness"
+            exit 1
+          fi
+
+          sudo EXPECT_EXIT_CODE=0 EXPECT_STDOUT_CONTAINS=Hop "$test_bin" --exact privilege_probe_smoke --nocapture
+
+  privilege-probe-smoke-windows-elevated-self-hosted:
+    name: Privilege probe smoke (windows, elevated self-hosted)
+    runs-on: [self-hosted, Windows, X64, elevated]
+    needs: pre-commit
+    if: github.event_name == 'workflow_dispatch' && inputs.run_windows_elevated_self_hosted
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Run elevated privilege smoke harness
+        shell: pwsh
+        run: |
+          $env:EXPECT_EXIT_CODE = "0"
+          $env:EXPECT_STDOUT_CONTAINS = "Hop"
+          cargo test --test privilege_probe_smoke -- --exact privilege_probe_smoke --nocapture
+
+  privilege-probe-smoke-windows-elevated-note:
+    name: Privilege probe smoke (windows, elevated lane note)
+    runs-on: windows-latest
+    needs: pre-commit
+    if: github.event_name != 'workflow_dispatch' || !inputs.run_windows_elevated_self_hosted
+
+    steps:
+      - name: Document GitHub-hosted Windows elevation constraint
+        shell: pwsh
+        run: |
+          "GitHub-hosted windows-latest runners cannot be interactively elevated; elevated probe smoke is provided via the optional self-hosted 'elevated' lane." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,7 @@ jobs:
           CARGO_INCREMENTAL: 0
           EXPECT_EXIT_CODE: "1"
           EXPECT_STDERR_ANY_OF: ${{ matrix.expected_stderr_any_of }}
+          SMOKE_ARGS: "-n -r -c 1 127.0.0.1"
 
   privilege-probe-smoke-linux-privileged:
     name: Privilege probe smoke (ubuntu-latest, elevated)
@@ -512,7 +513,7 @@ jobs:
             exit 1
           fi
 
-          sudo EXPECT_EXIT_CODE=0 EXPECT_STDOUT_CONTAINS=Hop "$test_bin" --exact privilege_probe_smoke --nocapture
+          sudo EXPECT_EXIT_CODE=0 EXPECT_STDOUT_CONTAINS=Hop SMOKE_ARGS="-n -r -c 1 127.0.0.1" "$test_bin" --exact privilege_probe_smoke --nocapture
 
   privilege-probe-smoke-windows-elevated-self-hosted:
     name: Privilege probe smoke (windows, elevated self-hosted)
@@ -534,6 +535,7 @@ jobs:
         run: |
           $env:EXPECT_EXIT_CODE = "0"
           $env:EXPECT_STDOUT_CONTAINS = "Hop"
+          $env:SMOKE_ARGS = "-n -r -c 1 127.0.0.1"
           cargo test --test privilege_probe_smoke -- --exact privilege_probe_smoke --nocapture
 
   privilege-probe-smoke-windows-elevated-note:

--- a/tests/privilege_probe_smoke.rs
+++ b/tests/privilege_probe_smoke.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::process::Command;
 
 fn parse_args(raw: &str) -> Vec<String> {
-    raw.split_whitespace().map(ToString::to_string).collect()
+    shlex::split(raw).unwrap_or_else(|| raw.split_whitespace().map(ToString::to_string).collect())
 }
 
 fn parse_alternatives(raw: &str) -> Vec<String> {
@@ -57,4 +57,25 @@ fn privilege_probe_smoke() {
             stderr
         );
     }
+}
+
+#[test]
+fn parse_args_supports_shell_quoting() {
+    let args = parse_args("--trippy-flags \"--log-format json --verbose\" -c 1 127.0.0.1");
+    assert_eq!(
+        args,
+        vec![
+            "--trippy-flags",
+            "--log-format json --verbose",
+            "-c",
+            "1",
+            "127.0.0.1",
+        ]
+    );
+}
+
+#[test]
+fn parse_alternatives_drops_empty_entries() {
+    let values = parse_alternatives("foo|| ||bar||");
+    assert_eq!(values, vec!["foo", "bar"]);
 }

--- a/tests/privilege_probe_smoke.rs
+++ b/tests/privilege_probe_smoke.rs
@@ -1,0 +1,60 @@
+use std::env;
+use std::process::Command;
+
+fn parse_args(raw: &str) -> Vec<String> {
+    raw.split_whitespace().map(ToString::to_string).collect()
+}
+
+fn parse_alternatives(raw: &str) -> Vec<String> {
+    raw.split("||")
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[test]
+fn privilege_probe_smoke() {
+    let binary = env!("CARGO_BIN_EXE_mtr");
+    let args = env::var("SMOKE_ARGS").unwrap_or_else(|_| "-n -r -c 1 127.0.0.1".to_string());
+    let expected_exit = match env::var("EXPECT_EXIT_CODE") {
+        Ok(value) => value
+            .parse::<i32>()
+            .expect("EXPECT_EXIT_CODE must be an integer"),
+        Err(_) => {
+            eprintln!("skipping privilege smoke: EXPECT_EXIT_CODE is not set");
+            return;
+        }
+    };
+
+    let output = Command::new(binary)
+        .args(parse_args(&args))
+        .output()
+        .expect("failed to execute smoke probe command");
+
+    let actual_exit = output.status.code().unwrap_or(2);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        actual_exit, expected_exit,
+        "unexpected exit code for `{binary} {args}`\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    if let Ok(expected_stdout) = env::var("EXPECT_STDOUT_CONTAINS") {
+        assert!(
+            stdout.contains(&expected_stdout),
+            "expected stdout to contain `{expected_stdout}`\nactual stdout:\n{stdout}"
+        );
+    }
+
+    if let Ok(expected_stderr_any_of) = env::var("EXPECT_STDERR_ANY_OF") {
+        let alternatives = parse_alternatives(&expected_stderr_any_of);
+        assert!(
+            alternatives.iter().any(|needle| stderr.contains(needle)),
+            "expected stderr to contain one of {:?}\nactual stderr:\n{}",
+            alternatives,
+            stderr
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure CI explicitly validates probe behavior across the privilege boundary so privilege-required modes fail gracefully for non-elevated runs and succeed when elevated. 
- Cover both Linux and Windows runners and document GitHub-hosted runner constraints for Windows elevation. 
- Provide a deterministic, env-driven smoke harness so CI can assert exit codes and user-facing error text reliably. 

### Description
- Add an integration-style smoke test `tests/privilege_probe_smoke.rs` that runs the built `mtr` binary and asserts deterministic exit code via `EXPECT_EXIT_CODE` and optional text checks via `EXPECT_STDOUT_CONTAINS` and `EXPECT_STDERR_ANY_OF` (alternatives `||`-delimited), and which no-ops when `EXPECT_EXIT_CODE` is unset. 
- Extend `.github/workflows/ci.yml` with a `workflow_dispatch` input `run_windows_elevated_self_hosted` and new jobs: a matrix `privilege-probe-smoke` on `ubuntu-latest`/`windows-latest` for non-elevated checks, `privilege-probe-smoke-linux-privileged` that builds the harness and runs it under `sudo` expecting success, an opt-in `privilege-probe-smoke-windows-elevated-self-hosted` lane for elevated self-hosted Windows runners, and a documentation job `privilege-probe-smoke-windows-elevated-note` that records GitHub-hosted Windows elevation constraints. 
- The elevated Linux job runs the compiled test binary directly (found under `target/debug/deps`) under `sudo` to validate privileged startup and probing. 

### Testing
- Ran formatter and linter: `cargo +stable fmt --all -- --check` and `cargo +stable clippy --all-targets --all-features -- -D warnings`, and both completed successfully. 
- Ran full test suite with `cargo +stable test --all` and confirmed all unit and integration tests passed including the new smoke harness. 
- Manually validated harness scenarios in this environment: a privileged success run with `EXPECT_EXIT_CODE=0 EXPECT_STDOUT_CONTAINS=Hop cargo +stable test --test privilege_probe_smoke -- --exact privilege_probe_smoke --nocapture` passed, and a non-elevated failure run using a non-privileged user (`sudo -u nobody ...`) with `EXPECT_EXIT_CODE=1` and `EXPECT_STDERR_ANY_OF='privileges are required'` also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f960a3a08330afb5b37ee9619b66)