### PR TITLE
Add fuzz harness + CI fuzz-smoke job and extract passthrough parsing to module

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,7 @@ on:
       - 'deny.toml'
       - 'src/**'
       - 'xtask/**'
+      - 'fuzz/**'
       - '.github/workflows/security.yml'
   push:
     branches: [ master ]
@@ -23,6 +24,7 @@ on:
       - 'deny.toml'
       - 'src/**'
       - 'xtask/**'
+      - 'fuzz/**'
       - '.github/workflows/security.yml'
 
 permissions:
@@ -76,4 +78,44 @@ jobs:
             echo "### Notes"
             echo "- cargo-deny config: \`deny.toml\`"
             echo "- Rust toolchain pinned to 1.88.0 for security checks"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+
+  fuzz-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Rust nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+
+      - name: Cache Cargo dependencies and installed binaries
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          shared-key: "rust-fuzz-smoke-nightly"
+          cache-bin: true
+          cache-on-failure: true
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Run fuzz smoke target (passthrough_flags)
+        id: fuzz_passthrough_flags
+        working-directory: fuzz
+        run: cargo fuzz run passthrough_flags -- -max_total_time=30
+
+      - name: Fuzz summary
+        if: always()
+        run: |
+          {
+            echo "## Fuzz smoke workflow summary"
+            echo ""
+            echo "- passthrough_flags: ${{ steps.fuzz_passthrough_flags.outcome }}"
+            echo ""
+            echo "### Notes"
+            echo "- libFuzzer target: \`fuzz/fuzz_targets/passthrough_flags.rs\`"
+            echo "- Runtime budget: 30s"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.88.0"
 
 [workspace]
 members = ["xtask"]
+exclude = ["fuzz"]
 
 [dependencies]
 trippy = "0.13.0"

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://loggin
 </tr>
 <tr>
   <td>Security hardening gates (cargo-audit + fuzz harness in CI)</td>
-  <td>🚧 In Progress (cargo-audit live, fuzz harness pending)</td>
+  <td>✅ Released (cargo-audit + fuzz harness live in CI)</td>
   <td>H2 2026</td>
 </tr>
 <tr>
@@ -420,11 +420,21 @@ To run the same repository-wide hook suite used in CI:
 
 ```bash
 python -m pip install pre-commit
-Before running local pre-commit hooks, install Rust via [rustup](https://www.rust-lang.org/tools/install) and make sure `cargo` is available on your `PATH`:
+```
+
+Before running local pre-commit hooks, install Rust via [rustup](https://www.rust-lang.org/tools/install) and make sure `cargo` is available on your `PATH`.
 
 ```bash
 pre-commit run --all-files
 ```
+
+To run the fuzz smoke harness locally (nightly toolchain required):
+
+```bash
+cargo install cargo-fuzz --locked
+(cd fuzz && cargo fuzz run passthrough_flags -- -max_total_time=30)
+```
+
 
 ## 📜 License
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+/artifacts
+/corpus
+/target
+/Cargo.lock

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "windows-mtr-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+windows-mtr = { path = ".." }
+
+[[bin]]
+name = "passthrough_flags"
+path = "fuzz_targets/passthrough_flags.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/passthrough_flags.rs
+++ b/fuzz/fuzz_targets/passthrough_flags.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use windows_mtr::passthrough::parse_passthrough_flags;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(input) = std::str::from_utf8(data) {
+        let _ = parse_passthrough_flags(input);
+    }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod passthrough;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::io::Write;
 use std::net::{IpAddr, ToSocketAddrs};
 use std::process::{self, Command, Stdio};
+use windows_mtr::passthrough::parse_passthrough_flags;
 
 mod error;
 use error::{MtrError, Result};
@@ -268,7 +269,8 @@ fn verify_options(args: &Cli) -> Result<()> {
     }
 
     if let Some(flags) = &args.trippy_flags {
-        let parsed = parse_passthrough_flags(flags)?;
+        let parsed = parse_passthrough_flags(flags)
+            .map_err(|msg| MtrError::InvalidOption(msg.to_string()))?;
         let conflicting = [
             "--tui-latency-warn-threshold",
             "--tui-latency-bad-threshold",
@@ -311,65 +313,6 @@ fn duration_seconds(value: f32) -> String {
     } else {
         format!("{value}s")
     }
-}
-
-fn split_wrapped_passthrough_token(token: &str) -> Vec<String> {
-    let mut result = Vec::new();
-    let mut current = String::new();
-    let mut active_quote: Option<char> = None;
-
-    for ch in token.chars() {
-        if let Some(quote) = active_quote {
-            if ch == quote {
-                active_quote = None;
-            } else {
-                current.push(ch);
-            }
-            continue;
-        }
-
-        if ch.is_whitespace() {
-            if !current.is_empty() {
-                result.push(std::mem::take(&mut current));
-            }
-            continue;
-        }
-
-        if (ch == '\'' || ch == '"') && current.is_empty() {
-            active_quote = Some(ch);
-            continue;
-        }
-
-        current.push(ch);
-    }
-
-    if let Some(quote) = active_quote {
-        current.insert(0, quote);
-    }
-
-    if !current.is_empty() {
-        result.push(current);
-    }
-
-    result
-}
-
-fn parse_passthrough_flags(flags: &str) -> Result<Vec<String>> {
-    let parsed = shlex::split(flags).ok_or_else(|| {
-        MtrError::InvalidOption("--trippy-flags contains invalid shell quoting".to_string())
-    })?;
-
-    // Windows shells sometimes preserve wrapping quotes around the entire passthrough
-    // string, which can produce a single token like "--flag value". Split that token
-    // into distinct argv entries while preserving embedded quoted segments.
-    if parsed.len() == 1 {
-        let token = &parsed[0];
-        if token.starts_with("--") && token.contains(' ') {
-            return Ok(split_wrapped_passthrough_token(token));
-        }
-    }
-
-    Ok(parsed)
 }
 
 fn build_embedded_trippy_args(args: &Cli, host: &str) -> Result<Vec<String>> {
@@ -461,7 +404,10 @@ fn build_embedded_trippy_args(args: &Cli, host: &str) -> Result<Vec<String>> {
     }
 
     if let Some(extra) = &args.trippy_flags {
-        trippy_args.extend(parse_passthrough_flags(extra)?);
+        trippy_args.extend(
+            parse_passthrough_flags(extra)
+                .map_err(|msg| MtrError::InvalidOption(msg.to_string()))?,
+        );
     }
 
     trippy_args.push(host.to_string());
@@ -644,10 +590,7 @@ mod tests {
 
     #[test]
     fn parse_passthrough_flags_rejects_invalid_shell_quoting() {
-        assert!(matches!(
-            parse_passthrough_flags("--foo 'bar"),
-            Err(MtrError::InvalidOption(_))
-        ));
+        assert!(parse_passthrough_flags("--foo 'bar").is_err());
     }
 
     #[test]

--- a/src/passthrough.rs
+++ b/src/passthrough.rs
@@ -1,0 +1,58 @@
+const INVALID_SHELL_QUOTING_MSG: &str = "--trippy-flags contains invalid shell quoting";
+
+pub fn split_wrapped_passthrough_token(token: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut current = String::new();
+    let mut active_quote: Option<char> = None;
+
+    for ch in token.chars() {
+        if let Some(quote) = active_quote {
+            if ch == quote {
+                active_quote = None;
+            } else {
+                current.push(ch);
+            }
+            continue;
+        }
+
+        if ch.is_whitespace() {
+            if !current.is_empty() {
+                result.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+
+        if (ch == '\'' || ch == '"') && current.is_empty() {
+            active_quote = Some(ch);
+            continue;
+        }
+
+        current.push(ch);
+    }
+
+    if let Some(quote) = active_quote {
+        current.insert(0, quote);
+    }
+
+    if !current.is_empty() {
+        result.push(current);
+    }
+
+    result
+}
+
+pub fn parse_passthrough_flags(flags: &str) -> std::result::Result<Vec<String>, &'static str> {
+    let parsed = shlex::split(flags).ok_or(INVALID_SHELL_QUOTING_MSG)?;
+
+    // Windows shells sometimes preserve wrapping quotes around the entire passthrough
+    // string, which can produce a single token like "--flag value". Split that token
+    // into distinct argv entries while preserving embedded quoted segments.
+    if parsed.len() == 1 {
+        let token = &parsed[0];
+        if token.starts_with("--") && token.contains(' ') {
+            return Ok(split_wrapped_passthrough_token(token));
+        }
+    }
+
+    Ok(parsed)
+}


### PR DESCRIPTION
### Motivation

- Add a lightweight libFuzzer harness and CI smoke job to catch regressions in passthrough flag parsing. 
- Move passthrough flag parsing out of `main.rs` to a dedicated module to improve testability and reuse. 
- Keep the fuzz artifacts out of the main workspace and document how to run the fuzz smoke harness locally.

### Description

- Added a `fuzz` crate with `fuzz/Cargo.toml`, a `passthrough_flags` fuzz target at `fuzz/fuzz_targets/passthrough_flags.rs`, and a `fuzz/.gitignore` to ignore fuzz artifacts. 
- Updated GitHub Actions security workflow (`.github/workflows/security.yml`) to include `fuzz/**` in path filters and added a `fuzz-smoke` job that installs `cargo-fuzz` on nightly and runs `cargo fuzz run passthrough_flags -- -max_total_time=30`. 
- Extracted passthrough parsing into `src/passthrough.rs` and exposed it via `src/lib.rs`, updating callers in `src/main.rs` to map the new parse error to `MtrError::InvalidOption`. 
- Excluded the `fuzz` directory from the workspace in `Cargo.toml` and updated `README.md` to mark CI fuzzing as live and to add local instructions for running the smoke harness.

### Testing

- Ran unit tests with `cargo test`, which succeeded. 
- Executed the fuzz smoke harness locally with `cargo fuzz run passthrough_flags -- -max_total_time=30`, which completed without crashes. 
- The new `fuzz-smoke` job is configured to run in CI as part of the updated `security` workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f76053d88330ae72bd92854bee9e)