### PR TITLE
Add CLI tests for privilege diagnostics and protocol port validation

### DIFF
--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,5 +1,11 @@
 use std::process::Command;
 
+#[allow(dead_code)]
+#[path = "../src/error.rs"]
+mod error;
+
+use error::MtrError;
+
 #[test]
 fn test_help_output() {
     let output = Command::new("cargo")
@@ -64,6 +70,71 @@ fn test_enhanced_wrapper_conflicts_with_passthrough_override() {
     let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
     assert!(
         stderr.contains("--trippy-flags cannot override windows-mtr enhanced UI wrapper settings")
+    );
+}
+
+#[test]
+fn test_insufficient_privileges_diagnostic_contract_is_stable() {
+    let error = MtrError::InsufficientPrivileges;
+    let message = error.to_string();
+
+    assert!(
+        matches!(error, MtrError::InsufficientPrivileges),
+        "Expected explicit InsufficientPrivileges error category to remain present",
+    );
+    assert!(
+        message.contains("Administrator privileges are required to run traceroute"),
+        "Expected insufficient privilege diagnostics to keep user-readable summary",
+    );
+    assert!(
+        message.contains("Run as administrator"),
+        "Expected insufficient privilege diagnostics to include actionable guidance",
+    );
+}
+
+#[test]
+fn test_tcp_without_port_exits_with_error_and_actionable_guidance() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "-T", "8.8.8.8"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit for TCP mode without required port",
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(
+        stderr.contains("Port option required for TCP protocol"),
+        "Expected protocol-specific error instead of silent fallback to another probe mode",
+    );
+    assert!(
+        stderr.contains("Example: windows-mtr.exe -T -P 443 8.8.8.8"),
+        "Expected actionable guidance for TCP privilege/usage diagnostics",
+    );
+}
+
+#[test]
+fn test_udp_without_port_exits_with_error_and_actionable_guidance() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "-U", "8.8.8.8"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        !output.status.success(),
+        "Expected non-zero exit for UDP mode without required port",
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(
+        stderr.contains("Port option required for UDP protocol"),
+        "Expected protocol-specific error instead of silent fallback to another probe mode",
+    );
+    assert!(
+        stderr.contains("Example: windows-mtr.exe -U -P 443 8.8.8.8"),
+        "Expected actionable guidance for UDP privilege/usage diagnostics",
     );
 }
 


### PR DESCRIPTION
### Motivation

- Ensure diagnostic messages and error categories remain stable and actionable for CLI users.  
- Validate that protocol-specific modes (`-T`/`-U`) require a port and emit clear guidance instead of falling back silently.  

### Description

- Import the error module (`#[path = "../src/error.rs"] mod error;`) and reference `MtrError` to assert diagnostic contracts.  
- Add `test_insufficient_privileges_diagnostic_contract_is_stable` to verify the `MtrError::InsufficientPrivileges` variant and that its `to_string()` contains both a user-readable summary and actionable guidance.  
- Add `test_tcp_without_port_exits_with_error_and_actionable_guidance` and `test_udp_without_port_exits_with_error_and_actionable_guidance` to assert non-zero exit status and that `stderr` contains protocol-specific error messages and usage examples.  

### Testing

- Ran `cargo test` which executed the updated CLI test suite including the new tests.  
- The new tests `test_insufficient_privileges_diagnostic_contract_is_stable`, `test_tcp_without_port_exits_with_error_and_actionable_guidance`, and `test_udp_without_port_exits_with_error_and_actionable_guidance` passed.  
- Existing CLI tests (help/version/report-mode checks) were also executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f9627ae08330b440366db3b282d1)