### PR TITLE
Mark probe parity and privilege smoke roadmap item as complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://loggin
 </tr>
 <tr>
   <td>Cross-platform probe parity/privilege smoke tests</td>
-  <td>🚧 In Progress (cross-OS CI live, probe privilege smoke tests pending)</td>
+  <td>✅ Released (CI `Probe parity (windows-latest|ubuntu-latest)` + privilege smoke lanes: `Privilege probe smoke (ubuntu-latest|windows-latest, non-elevated)`, `Privilege probe smoke (ubuntu-latest, elevated)`, and optional `Privilege probe smoke (windows, elevated self-hosted)`; coverage includes non-elevated failures on Windows/Ubuntu and elevated success on Ubuntu + Windows self-hosted; constraint: elevated Windows lane requires self-hosted runner because GitHub-hosted `windows-latest` cannot be interactively elevated.)</td>
   <td>H2 2026</td>
 </tr>
 <tr>


### PR DESCRIPTION
### Motivation
- Reflect that cross-platform probe parity and privilege smoke checks are implemented in CI and the roadmap should be updated to show that work complete.

### Description
- Update the README roadmap row for “Cross-platform probe parity/privilege smoke tests” to ✅ Released and add brief completion evidence naming the CI jobs and the Windows self-hosted elevation constraint.

### Testing
- No automated test runs were required for this documentation-only change; I statically verified the CI configuration defines `probe-parity` and the privilege smoke lanes (`privilege-probe-smoke`, `privilege-probe-smoke (ubuntu-latest, elevated)`, and the optional `privilege-probe-smoke-windows-elevated-self-hosted`) and confirmed the smoke harness exists at `tests/privilege_probe_smoke.rs` which those jobs execute.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40a6a648c83308c61e01d99dbd996)