### PR TITLE
Add ROADMAP.md and reference it from README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://loggin
 ## 📋 Documentation
 
 - [📚 Full Documentation Hub](docs/README.md)
+- [🛣️ Product Roadmap](docs/ROADMAP.md)
 - [🧩 CLI/API Reference](docs/API.md)
 - [🧪 Probe parity matrix](docs/probe-parity.md)
 - [📑 Usage Examples](docs/USAGE.md)
@@ -314,108 +315,13 @@ mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://loggin
 
 ## 📊 Project Status & Roadmap
 
-<table>
-<tr>
-  <th>Feature</th>
-  <th>Status</th>
-  <th>Timeline</th>
-</tr>
-<tr>
-  <td>Core MTR Functionality</td>
-  <td>✅ Released</td>
-  <td>v1.0.0</td>
-</tr>
-<tr>
-  <td>MSI Installer</td>
-  <td>✅ Released</td>
-  <td>v1.0.0</td>
-</tr>
-<tr>
-  <td>IPv6 Support</td>
-  <td>✅ Released</td>
-  <td>v1.0.0</td>
-</tr>
-<tr>
-  <td>Docker Support</td>
-  <td>✅ Released</td>
-  <td>v1.0.0</td>
-</tr>
-<tr>
-  <td>Single portable executable</td>
-  <td>✅ Released</td>
-  <td>v1.1.3</td>
-</tr>
-<tr>
-  <td>JSON Output</td>
-  <td>✅ Released</td>
-  <td>v1.1.3</td>
-</tr>
-<tr>
-  <td>DNS Caching (TTL)</td>
-  <td>✅ Released</td>
-  <td>v1.1.3</td>
-</tr>
-<tr>
-  <td>CI matrix coverage (Windows + Ubuntu, MSRV + stable)</td>
-  <td>✅ Released</td>
-  <td>v1.2.x</td>
-</tr>
-<tr>
-  <td>CodeQL workflow for Rust</td>
-  <td>✅ Released</td>
-  <td>v1.2.x</td>
-</tr>
-<tr>
-  <td>Container publishing to GHCR + Docker Hub</td>
-  <td>✅ Released</td>
-  <td>v1.2.x</td>
-</tr>
-<tr>
-  <td>REST API</td>
-  <td>📅 Planned</td>
-  <td>H2 2026</td>
-</tr>
-<tr>
-  <td>SNMP Integration</td>
-  <td>📅 Planned</td>
-  <td>H2 2026</td>
-</tr>
-<tr>
-  <td>Native Ratatui UI (tabs, hop table, charts)</td>
-  <td>✅ Released (`--ui native`)</td>
-  <td>H2 2026</td>
-</tr>
-<tr>
-  <td>ETW + Windows observability integrations</td>
-  <td>🛣️ Roadmap</td>
-  <td>H2 2026</td>
-</tr>
-<tr>
-  <td>Versioned JSON schema + CSV export</td>
-  <td>🛣️ Roadmap</td>
-  <td>H2 2026</td>
-</tr>
-<tr>
-  <td>Security hardening gates (cargo-audit + fuzz harness in CI)</td>
-  <td>🚧 In Progress (cargo-audit live, fuzz harness pending)</td>
-  <td>H2 2026</td>
-</tr>
-<tr>
-  <td>Cross-platform probe parity/privilege smoke tests</td>
-  <td>✅ Released (CI `Probe parity (windows-latest|ubuntu-latest)` + privilege smoke lanes: `Privilege probe smoke (ubuntu-latest|windows-latest, non-elevated)`, `Privilege probe smoke (ubuntu-latest, elevated)`, and optional `Privilege probe smoke (windows, elevated self-hosted)`; coverage includes non-elevated failures on Windows/Ubuntu and elevated success on Ubuntu + Windows self-hosted; constraint: elevated Windows lane requires self-hosted runner because GitHub-hosted `windows-latest` cannot be interactively elevated.)</td>
-  <td>H2 2026</td>
-</tr>
-<tr>
-  <td>GitHub Actions hardening (pin workflow actions by commit SHA)</td>
-  <td>✅ Released</td>
-  <td>v1.2.x</td>
-</tr>
-<tr>
-  <td>CLI/runtime cleanup (unused error variants, banner polish)</td>
-  <td>🛣️ Roadmap</td>
-  <td>H2 2026</td>
-</tr>
-</table>
+The full roadmap now lives in [docs/ROADMAP.md](docs/ROADMAP.md), which is the single source of truth for feature status and planned milestones.
+
+Quick snapshot:
+
+- ✅ Released: Core MTR functionality, MSI installer, IPv6, Docker, JSON output, DNS cache TTL.
+- 🚧 In progress: Security hardening gates (`cargo-audit` in CI, fuzz harness pending).
+- 📅 Planned / 🛣️ Roadmap: REST API, SNMP integration, ETW observability, versioned JSON schema + CSV export, runtime cleanup.
 
 ## 🤝 Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Welcome to the documentation hub for **Windows MTR**, a Windows-native, enterpri
 - [Installation Guide](INSTALLATION.md)
 - [Usage Guide](USAGE.md)
 - [API Reference](API.md)
+- [Roadmap](ROADMAP.md)
 - [Development Guide](../DEVELOPMENT.md)
 - [Contributing Guide](../CONTRIBUTING.md)
 
@@ -20,6 +21,7 @@ Welcome to the documentation hub for **Windows MTR**, a Windows-native, enterpri
   - [Development setup and workflow](../DEVELOPMENT.md)
   - [Contribution process and quality gates](../CONTRIBUTING.md)
   - [CLI/report API semantics](API.md)
+  - [Project roadmap and status](ROADMAP.md)
   - [Probe parity matrix](probe-parity.md)
   - [Branch review snapshot](BRANCH_REVIEW.md)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,40 @@
+# Windows MTR Roadmap
+
+This page tracks delivery status for major features and platform capabilities.
+
+For release-by-release details, see the [changelog](../CHANGELOG.md).
+
+## Status legend
+
+- ✅ Released
+- 🚧 In Progress
+- 📅 Planned
+- 🛣️ Roadmap
+
+## Delivery status
+
+| Feature | Status | Timeline |
+|---|---|---|
+| Core MTR Functionality | ✅ Released | v1.0.0 |
+| MSI Installer | ✅ Released | v1.0.0 |
+| IPv6 Support | ✅ Released | v1.0.0 |
+| Docker Support | ✅ Released | v1.0.0 |
+| Single portable executable | ✅ Released | v1.1.3 |
+| JSON Output | ✅ Released | v1.1.3 |
+| DNS Caching (TTL) | ✅ Released | v1.1.3 |
+| CI matrix coverage (Windows + Ubuntu, MSRV + stable) | ✅ Released | v1.2.x |
+| CodeQL workflow for Rust | ✅ Released | v1.2.x |
+| Container publishing to GHCR + Docker Hub | ✅ Released | v1.2.x |
+| REST API | 📅 Planned | H2 2026 |
+| SNMP Integration | 📅 Planned | H2 2026 |
+| Native Ratatui UI (tabs, hop table, charts) | ✅ Released (`--ui native`) | H2 2026 |
+| ETW + Windows observability integrations | 🛣️ Roadmap | H2 2026 |
+| Versioned JSON schema + CSV export | 🛣️ Roadmap | H2 2026 |
+| Security hardening gates (cargo-audit + fuzz harness in CI) | 🚧 In Progress (cargo-audit live, fuzz harness pending) | H2 2026 |
+| Cross-platform probe parity/privilege smoke tests | ✅ Released (CI `Probe parity (windows-latest\|ubuntu-latest)` + privilege smoke lanes: `Privilege probe smoke (ubuntu-latest\|windows-latest, non-elevated)`, `Privilege probe smoke (ubuntu-latest, elevated)`, and optional `Privilege probe smoke (windows, elevated self-hosted)`; coverage includes non-elevated failures on Windows/Ubuntu and elevated success on Ubuntu + Windows self-hosted; constraint: elevated Windows lane requires self-hosted runner because GitHub-hosted `windows-latest` cannot be interactively elevated.) | H2 2026 |
+| GitHub Actions hardening (pin workflow actions by commit SHA) | ✅ Released | v1.2.x |
+| CLI/runtime cleanup (unused error variants, banner polish) | 🛣️ Roadmap | H2 2026 |
+
+## Notes
+
+Roadmap dates and priorities can change based on stability, security, and user feedback.


### PR DESCRIPTION
### Motivation

- Centralize project roadmap and feature status into a single source of truth instead of a long inline table in the top-level `README.md`.

### Description

- Add a new `docs/ROADMAP.md` file that contains the feature delivery status table and notes.
- Replace the large roadmap HTML table in `README.md` with a concise link to `docs/ROADMAP.md` and a short snapshot summary.
- Update `docs/README.md` to include a link to the new `ROADMAP.md` so the documentation hub references the roadmap.

### Testing

- Run `pre-commit run --all-files` to validate formatting and hooks, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b8caf1d48330aa2b8edcd0ad72c6)