### PR TITLE
Add ADR 0001 for REST API stack and minimal dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ shlex = "1.3.0"
 serde_json = "1.0.149"
 ratatui = "0.29.0"
 crossterm = "0.28.1"
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "net"] }
+axum = "0.8.4"
+serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
 regex = "1.10.3"

--- a/docs/adr/0001-rest-api-stack.md
+++ b/docs/adr/0001-rest-api-stack.md
@@ -1,0 +1,88 @@
+# ADR 0001: REST API runtime, JSON model, and lifecycle
+
+- Status: Accepted
+- Date: 2026-03-14
+
+## Context
+
+`windows-mtr` is currently a CLI-first diagnostics tool (`mtr`) with stable command behavior and script compatibility expectations. We want to add a REST API surface for automation and integration use cases without regressing existing CLI workflows.
+
+The API stack should:
+
+- Reuse Rust ecosystem components with strong production maturity.
+- Preserve current CLI compatibility by default.
+- Keep dependency expansion minimal and auditable.
+- Support explicit, predictable shutdown semantics so in-flight probes are handled cleanly.
+
+## Decision
+
+### 1) Runtime and framework
+
+Use **Tokio + Axum** for the v1 REST API server:
+
+- Runtime: `tokio` (multi-thread runtime + signal handling)
+- HTTP framework: `axum`
+
+### 2) JSON serialization approach
+
+Use `serde` for DTO derives and `axum::Json<T>` for request/response binding.
+
+`serde_json` remains the underlying JSON codec and can also be used directly when constructing explicit JSON payloads.
+
+### 3) Graceful shutdown model
+
+Use a **signal-driven graceful shutdown** model with Tokio:
+
+- Listen for `Ctrl+C` via `tokio::signal::ctrl_c()`.
+- Trigger Axum server shutdown through `with_graceful_shutdown(...)`.
+- Stop accepting new connections after shutdown is triggered.
+- Allow in-flight request handlers to complete before process exit.
+
+For v1, no custom background job draining protocol is introduced beyond request completion.
+
+### 4) Process model / binary layout
+
+Run the API as a **separate binary** (recommended path):
+
+- Keep `mtr` as the current CLI binary with unchanged behavior.
+- Add API serving as a distinct executable in a future implementation phase.
+
+This preserves CLI compatibility and avoids surprising behavior from additional mode flags in the main binary startup path.
+
+## Minimal dependency set in `Cargo.toml`
+
+The API stack introduces only these new crates:
+
+1. `tokio` with `rt-multi-thread`, `macros`, `signal`, `net`
+   - Why: async runtime, entrypoint macro, signal handling, and socket server support.
+   - Security/perf rationale: mature runtime with broad ecosystem scrutiny; efficient async I/O scheduling for many concurrent lightweight requests.
+2. `axum`
+   - Why: routing, extraction, response handling, and built-in graceful shutdown integration.
+   - Security/perf rationale: strongly typed extractors reduce input handling errors; built on Hyper/Tower with efficient request pipeline composition.
+3. `serde` with `derive`
+   - Why: explicit schema structs for request/response serialization.
+   - Security/perf rationale: typed schema boundaries reduce ad-hoc parsing bugs; derive-based serialization avoids bespoke codec logic and unnecessary allocations from manual map construction.
+
+No additional persistence, auth, or distributed systems crates are added in v1 to keep the trusted dependency base minimal.
+
+## Consequences
+
+### Positive
+
+- Preserves existing CLI behavior and invocation contracts.
+- Uses common, well-maintained Rust async/web stack.
+- Keeps implementation straightforward for future API endpoints.
+- Provides deterministic server lifecycle behavior on shutdown.
+
+### Trade-offs
+
+- Separate binary adds one more deliverable artifact.
+- Initial API implementation remains intentionally narrow and does not solve multi-node/stateful orchestration concerns.
+
+## Explicit non-goals for v1 API
+
+- No long-term persistence/database storage.
+- No distributed coordination or leader election.
+- No cross-process/shared-state clustering.
+- No websocket/streaming protocol commitment (REST only for v1).
+- No implicit changes to existing CLI defaults or output formats.


### PR DESCRIPTION
### Motivation
- Establish a minimal, reviewable architecture baseline for a v1 REST API that preserves existing CLI behavior and limits dependency growth. 
- Select a production-ready async/web stack with clear shutdown semantics to make future API implementation predictable. 
- Document explicit v1 non-goals to avoid scope creep (no persistence, no distributed coordination, no streaming/websocket commitment). 

### Description
- Add ADR file `docs/adr/0001-rest-api-stack.md` that chooses `tokio + axum` as the runtime/framework, `serde` + `axum::Json`/`serde_json` for JSON, and a `tokio::signal::ctrl_c()`-driven graceful shutdown model. 
- Update `Cargo.toml` to add the minimal crates required for this stack: `tokio` (with `rt-multi-thread`, `macros`, `signal`, `net`), `axum`, and `serde` (with `derive`). 
- Recommend running the API as a separate binary to preserve CLI compatibility and avoid altering `mtr` startup behavior. 

### Testing
- Ran `cargo fmt --all -- --check` and it succeeded. 
- Ran `cargo clippy --all-targets --all-features -- -D warnings` and it failed due to the environment using `rustc 1.87.0` while the project/dependencies require `rustc 1.88.0`. 
- Ran `cargo test --all` and it could not run for the same `rustc` version mismatch (`1.87.0` vs required `1.88.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ca41b1f08330a16dd7df73e6e86f)