### PR TITLE
Add OpenAPI v1 spec and contract tests for HTTP probe API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
 regex = "1.10.3"
+serde_yaml = "0.9.34"
 
 [profile.release]
 lto = true

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,405 @@
+openapi: 3.1.0
+info:
+  title: windows-mtr HTTP API
+  version: 0.1.0
+  description: |
+    Initial v1 contract for a service wrapper around windows-mtr probe/report concepts.
+
+    ## Mapping from CLI/report concepts (`USAGE.md`)
+    - Report row semantics (`Loss%`, `Snt`, `Last`, `Avg`, `Best`, `Wrst`, `StDev`) map to per-hop API fields:
+      `loss_pct`, `sent`, `last_ms`, `avg_ms`, `best_ms`, `worst_ms`, `stddev_ms`.
+    - JSON/report host identity maps to `host`, optional `ip`, and optional `asn`.
+    - `-c` maps to `count` in create-probe requests.
+    - `-m` maps to `max_hops` in create-probe requests.
+    - `-n` maps to `resolve_dns` (inverse semantics: `-n` means `resolve_dns=false`).
+
+    ## Explicitly out of scope for API v1 (CLI-only)
+    - Interactive UI presets/toggles: `--ui`, `--latency-warn-ms`, `--latency-bad-ms`,
+      `--loss-warn-pct`, `--loss-bad-pct`, `--enhanced-row-color`, `--enhanced-sparklines`,
+      `--enhanced-summary`.
+    - Raw passthrough flags (`--trippy-flags`) and direct rendering concerns (`-w/--report-wide`).
+    - Terminal interaction controls and live keybindings.
+servers:
+  - url: https://example.invalid
+    description: Placeholder server URL for contract documentation
+paths:
+  /api/v1/health:
+    get:
+      summary: Liveness and basic build metadata
+      operationId: getHealth
+      responses:
+        '200':
+          description: Service health response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+  /api/v1/probes:
+    post:
+      summary: Start a probe job
+      operationId: createProbe
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateProbeRequest'
+      responses:
+        '202':
+          description: Probe accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateProbeResponse'
+        '400':
+          description: Invalid request payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/probes/{id}:
+    get:
+      summary: Fetch probe result status and report snapshot
+      operationId: getProbe
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Probe state/result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetProbeResponse'
+        '400':
+          description: Invalid probe id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Probe not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    EnvelopeMeta:
+      type: object
+      required:
+        - schema_version
+      properties:
+        schema_version:
+          type: string
+          enum: [v1]
+          description: Contract schema version for response compatibility checks.
+          example: "v1"
+        request_id:
+          type: string
+          description: Correlation identifier for tracing/logging.
+      additionalProperties: false
+    ApiError:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: invalid_request
+        message:
+          type: string
+      additionalProperties: false
+    ErrorResponse:
+      type: object
+      required:
+        - meta
+        - error
+      properties:
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        error:
+          $ref: '#/components/schemas/ApiError'
+      additionalProperties: false
+    HealthData:
+      type: object
+      required:
+        - status
+        - service
+        - version
+      properties:
+        status:
+          type: string
+          enum: [ok]
+        service:
+          type: string
+          example: windows-mtr
+        version:
+          type: string
+          description: Service version (typically from package version)
+      additionalProperties: false
+    HealthResponse:
+      type: object
+      required:
+        - meta
+        - data
+      properties:
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        data:
+          $ref: '#/components/schemas/HealthData'
+      additionalProperties: false
+    CreateProbeRequest:
+      oneOf:
+        - $ref: '#/components/schemas/CreateProbeRequestIcmp'
+        - $ref: '#/components/schemas/CreateProbeRequestTcpUdp'
+      discriminator:
+        propertyName: protocol
+        mapping:
+          icmp: '#/components/schemas/CreateProbeRequestIcmp'
+          tcp: '#/components/schemas/CreateProbeRequestTcpUdp'
+          udp: '#/components/schemas/CreateProbeRequestTcpUdp'
+    CreateProbeRequestIcmp:
+      type: object
+      required:
+        - target
+      properties:
+        target:
+          type: string
+          description: Hostname or IP target (maps to CLI positional target).
+          example: 1.1.1.1
+        protocol:
+          type: string
+          enum: [icmp]
+          default: icmp
+        count:
+          type: integer
+          minimum: 1
+          description: Probe/report cycles (maps to `-c`).
+        max_hops:
+          type: integer
+          minimum: 1
+          maximum: 255
+          description: Maximum TTL/hops (maps to `-m`).
+        resolve_dns:
+          type: boolean
+          default: true
+          description: If false, API should return IP-only where possible (maps to `-n`).
+        include_asn:
+          type: boolean
+          default: false
+          description: Include ASN lookups when available (maps to `-b`/`-z`).
+      additionalProperties: false
+    CreateProbeRequestTcpUdp:
+      type: object
+      required:
+        - target
+        - protocol
+        - port
+      properties:
+        target:
+          type: string
+          description: Hostname or IP target (maps to CLI positional target).
+          example: 1.1.1.1
+        protocol:
+          type: string
+          enum: [tcp, udp]
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+          description: Required for tcp/udp probes (maps to `-P`, `--port`).
+        count:
+          type: integer
+          minimum: 1
+          description: Probe/report cycles (maps to `-c`).
+        max_hops:
+          type: integer
+          minimum: 1
+          maximum: 255
+          description: Maximum TTL/hops (maps to `-m`).
+        resolve_dns:
+          type: boolean
+          default: true
+          description: If false, API should return IP-only where possible (maps to `-n`).
+        include_asn:
+          type: boolean
+          default: false
+          description: Include ASN lookups when available (maps to `-b`/`-z`).
+      additionalProperties: false
+    CreateProbeData:
+      type: object
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: string
+          description: Stable probe identifier.
+        status:
+          type: string
+          enum: [pending, running, completed, failed]
+      additionalProperties: false
+    CreateProbeResponse:
+      type: object
+      required:
+        - meta
+        - data
+      properties:
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        data:
+          $ref: '#/components/schemas/CreateProbeData'
+      additionalProperties: false
+    HopResult:
+      type: object
+      required:
+        - hop_index
+        - host
+        - sent
+        - loss_pct
+        - last_ms
+        - avg_ms
+        - best_ms
+        - worst_ms
+        - stddev_ms
+      properties:
+        hop_index:
+          type: integer
+          minimum: 1
+        host:
+          type: string
+          description: Host label as rendered by report/JSON output.
+        ip:
+          type: string
+          description: IP address when known.
+        asn:
+          type: string
+          description: ASN text when ASN lookup is enabled.
+        sent:
+          type: integer
+          minimum: 0
+          description: Sent probes (maps to report `Snt`).
+        loss_pct:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 100
+          description: Loss percentage (maps to report `Loss%`).
+        last_ms:
+          type: number
+          format: float
+          minimum: 0
+        avg_ms:
+          type: number
+          format: float
+          minimum: 0
+        best_ms:
+          type: number
+          format: float
+          minimum: 0
+        worst_ms:
+          type: number
+          format: float
+          minimum: 0
+        stddev_ms:
+          type: number
+          format: float
+          minimum: 0
+      additionalProperties: false
+    ProbeSummary:
+      type: object
+      required:
+        - sent
+        - loss_pct
+        - last_ms
+        - avg_ms
+        - best_ms
+        - worst_ms
+        - stddev_ms
+        - hop_count
+      properties:
+        sent:
+          type: integer
+          minimum: 0
+        loss_pct:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 100
+        last_ms:
+          type: number
+          format: float
+          minimum: 0
+        avg_ms:
+          type: number
+          format: float
+          minimum: 0
+        best_ms:
+          type: number
+          format: float
+          minimum: 0
+        worst_ms:
+          type: number
+          format: float
+          minimum: 0
+        stddev_ms:
+          type: number
+          format: float
+          minimum: 0
+        hop_count:
+          type: integer
+          minimum: 0
+      additionalProperties: false
+    ProbeResultData:
+      type: object
+      required:
+        - id
+        - target
+        - protocol
+        - status
+        - hops
+        - summary
+      properties:
+        id:
+          type: string
+        target:
+          type: string
+        protocol:
+          type: string
+          enum: [icmp, tcp, udp]
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+        status:
+          type: string
+          enum: [pending, running, completed, failed]
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        hops:
+          type: array
+          items:
+            $ref: '#/components/schemas/HopResult'
+        summary:
+          $ref: '#/components/schemas/ProbeSummary'
+      additionalProperties: false
+    GetProbeResponse:
+      type: object
+      required:
+        - meta
+        - data
+      properties:
+        meta:
+          $ref: '#/components/schemas/EnvelopeMeta'
+        data:
+          $ref: '#/components/schemas/ProbeResultData'
+      additionalProperties: false

--- a/tests/api_contract_tests.rs
+++ b/tests/api_contract_tests.rs
@@ -1,0 +1,186 @@
+use serde::Deserialize;
+use serde_yaml::{Mapping, Value};
+use std::fs;
+
+#[derive(Debug, Deserialize)]
+struct ApiContractFixture {
+    required_paths: Vec<String>,
+    required_envelope_fields: Vec<String>,
+    required_hop_fields: Vec<String>,
+    required_probe_summary_fields: Vec<String>,
+    required_out_of_scope_cli_flags: Vec<String>,
+}
+
+fn load_fixture() -> ApiContractFixture {
+    let fixture_raw = fs::read_to_string("tests/fixtures/api_openapi_required_paths.yaml")
+        .expect("failed to read api contract fixture");
+    serde_yaml::from_str(&fixture_raw).expect("failed to parse api contract fixture")
+}
+
+fn load_openapi() -> Value {
+    let raw =
+        fs::read_to_string("docs/api/openapi.yaml").expect("failed to read docs/api/openapi.yaml");
+    serde_yaml::from_str(&raw).expect("failed to parse docs/api/openapi.yaml as yaml")
+}
+
+fn as_mapping(value: &Value) -> &Mapping {
+    value.as_mapping().expect("expected yaml mapping")
+}
+
+fn map_get<'a>(map: &'a Mapping, key: &str) -> &'a Value {
+    map.get(Value::String(key.to_string()))
+        .unwrap_or_else(|| panic!("missing key: {key}"))
+}
+
+fn map_get_optional<'a>(map: &'a Mapping, key: &str) -> Option<&'a Value> {
+    map.get(Value::String(key.to_string()))
+}
+
+fn required_property_names(schema: &Value) -> Vec<String> {
+    let schema_map = as_mapping(schema);
+    let required = map_get(schema_map, "required")
+        .as_sequence()
+        .expect("schema.required should be a sequence");
+
+    required
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .expect("required entries should be strings")
+                .to_string()
+        })
+        .collect()
+}
+
+fn schema_ref_at_operation_response(
+    paths: &Mapping,
+    path: &str,
+    method: &str,
+    status_code: &str,
+) -> String {
+    let operation = as_mapping(map_get(as_mapping(map_get(paths, path)), method));
+    let responses = as_mapping(map_get(operation, "responses"));
+    let response = as_mapping(map_get(responses, status_code));
+    let content = as_mapping(map_get(response, "content"));
+    let app_json = as_mapping(map_get(content, "application/json"));
+    map_get(app_json, "schema")
+        .as_mapping()
+        .and_then(|schema| schema.get(Value::String("$ref".to_string())))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("missing schema $ref for {method} {path} {status_code}"))
+        .to_string()
+}
+
+#[test]
+fn openapi_contract_has_required_paths_and_fields() {
+    let fixture = load_fixture();
+
+    let openapi = load_openapi();
+    let openapi_map = as_mapping(&openapi);
+
+    let paths = as_mapping(map_get(openapi_map, "paths"));
+    for required_path in &fixture.required_paths {
+        assert!(
+            map_get_optional(paths, required_path).is_some(),
+            "missing required path: {required_path}"
+        );
+    }
+
+    let components = as_mapping(map_get(openapi_map, "components"));
+    let schemas = as_mapping(map_get(components, "schemas"));
+
+    let envelope_meta_required = required_property_names(map_get(schemas, "EnvelopeMeta"));
+    for required in &fixture.required_envelope_fields {
+        assert!(
+            envelope_meta_required.iter().any(|field| field == required),
+            "EnvelopeMeta.required must contain {required}"
+        );
+    }
+
+    let hop_required = required_property_names(map_get(schemas, "HopResult"));
+    for required in &fixture.required_hop_fields {
+        assert!(
+            hop_required.iter().any(|field| field == required),
+            "HopResult.required must contain {required}"
+        );
+    }
+
+    let summary_required = required_property_names(map_get(schemas, "ProbeSummary"));
+    for required in &fixture.required_probe_summary_fields {
+        assert!(
+            summary_required.iter().any(|field| field == required),
+            "ProbeSummary.required must contain {required}"
+        );
+    }
+}
+
+#[test]
+fn openapi_contract_enforces_protocol_port_rules() {
+    let openapi = load_openapi();
+    let openapi_map = as_mapping(&openapi);
+    let components = as_mapping(map_get(openapi_map, "components"));
+    let schemas = as_mapping(map_get(components, "schemas"));
+
+    let create_request = as_mapping(map_get(schemas, "CreateProbeRequest"));
+    let one_of = map_get(create_request, "oneOf")
+        .as_sequence()
+        .expect("CreateProbeRequest.oneOf must be present")
+        .len();
+    assert_eq!(
+        one_of, 2,
+        "CreateProbeRequest should have ICMP and TCP/UDP variants"
+    );
+
+    let tcp_udp_required = required_property_names(map_get(schemas, "CreateProbeRequestTcpUdp"));
+    assert!(
+        tcp_udp_required.iter().any(|field| field == "port"),
+        "CreateProbeRequestTcpUdp must require port"
+    );
+}
+
+#[test]
+fn openapi_contract_uses_envelope_across_success_and_error() {
+    let openapi = load_openapi();
+    let openapi_map = as_mapping(&openapi);
+    let paths = as_mapping(map_get(openapi_map, "paths"));
+
+    assert_eq!(
+        schema_ref_at_operation_response(paths, "/api/v1/health", "get", "200"),
+        "#/components/schemas/HealthResponse"
+    );
+    assert_eq!(
+        schema_ref_at_operation_response(paths, "/api/v1/probes", "post", "202"),
+        "#/components/schemas/CreateProbeResponse"
+    );
+    assert_eq!(
+        schema_ref_at_operation_response(paths, "/api/v1/probes", "post", "400"),
+        "#/components/schemas/ErrorResponse"
+    );
+    assert_eq!(
+        schema_ref_at_operation_response(paths, "/api/v1/probes/{id}", "get", "200"),
+        "#/components/schemas/GetProbeResponse"
+    );
+    assert_eq!(
+        schema_ref_at_operation_response(paths, "/api/v1/probes/{id}", "get", "400"),
+        "#/components/schemas/ErrorResponse"
+    );
+    assert_eq!(
+        schema_ref_at_operation_response(paths, "/api/v1/probes/{id}", "get", "404"),
+        "#/components/schemas/ErrorResponse"
+    );
+}
+
+#[test]
+fn openapi_contract_documents_cli_only_v1_out_of_scope() {
+    let fixture = load_fixture();
+
+    let raw =
+        fs::read_to_string("docs/api/openapi.yaml").expect("failed to read docs/api/openapi.yaml");
+
+    for flag in &fixture.required_out_of_scope_cli_flags {
+        assert!(
+            raw.contains(flag),
+            "openapi description must document CLI-only out-of-scope flag: {flag}"
+        );
+    }
+}

--- a/tests/fixtures/api_openapi_required_paths.yaml
+++ b/tests/fixtures/api_openapi_required_paths.yaml
@@ -1,0 +1,36 @@
+required_paths:
+  - /api/v1/health
+  - /api/v1/probes
+  - /api/v1/probes/{id}
+required_envelope_fields:
+  - schema_version
+required_hop_fields:
+  - hop_index
+  - host
+  - sent
+  - loss_pct
+  - last_ms
+  - avg_ms
+  - best_ms
+  - worst_ms
+  - stddev_ms
+required_probe_summary_fields:
+  - sent
+  - loss_pct
+  - last_ms
+  - avg_ms
+  - best_ms
+  - worst_ms
+  - stddev_ms
+  - hop_count
+required_out_of_scope_cli_flags:
+  - --ui
+  - --latency-warn-ms
+  - --latency-bad-ms
+  - --loss-warn-pct
+  - --loss-bad-pct
+  - --enhanced-row-color
+  - --enhanced-sparklines
+  - --enhanced-summary
+  - --trippy-flags
+  - --report-wide


### PR DESCRIPTION
### Motivation
- Provide an initial HTTP API contract for a service wrapper around windows-mtr probe/report concepts to enable server-side implementations and clients. 
- Capture mapping from existing CLI/report semantics into stable JSON fields and explicitly document CLI-only features that are out of scope for v1.
- Enforce the contract with automated tests so the spec remains a reliable integration point.

### Description
- Add a full OpenAPI v1 contract at `docs/api/openapi.yaml` describing `/api/v1/health`, `/api/v1/probes` (POST) and `/api/v1/probes/{id}` (GET) plus comprehensive schemas for requests, responses, hops and summaries. 
- Add a contract test suite `tests/api_contract_tests.rs` that validates required paths, required schema fields, protocol/port rules, envelope usage for success/errors, and documentation of CLI-only out-of-scope flags. 
- Add a YAML fixture `tests/fixtures/api_openapi_required_paths.yaml` used by the tests to declare required paths and fields. 
- Add `serde_yaml = "0.9.34"` as a `dev-dependency` in `Cargo.toml` to parse the OpenAPI YAML in tests.

### Testing
- Ran the new contract tests via `cargo test` which exercises `tests/api_contract_tests.rs` against `docs/api/openapi.yaml` and the fixture; the suite passed. 
- Existing test harness was unchanged and the overall test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4cada3ca483309ef8b80e007c0a6a)