### PR TITLE
Add REST API security defaults, request validation, concurrency/rate guards, and refactor CLI to use service probe plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,20 @@ Windows MTR is built with enterprise-level security practices:
 - 🧪 Comprehensive fuzzing with 1000+ malformed packet tests
 - 🔑 Cryptographically signed releases with SHA-256 verification
 
+
+### REST API security and operational limits (v1 plan)
+
+For planned REST API deployments, the security baseline is:
+
+- Default bind address: `127.0.0.1:3000` (localhost only)
+- Non-local bind requires explicit opt-in + authentication (`X-API-Key` or mTLS)
+- Default request timeout: `10s`
+- Max concurrent probes: `8`
+- Max targets per request: `8`
+- Max payload size: `16 KiB`
+
+See [docs/security/rest-api.md](docs/security/rest-api.md) for the full threat model and controls.
+
 ## 💻 Installation
 
 > [!TIP]

--- a/USAGE.md
+++ b/USAGE.md
@@ -136,3 +136,26 @@ mtr --trippy-flags "--log-format json --verbose --tui-refresh-rate 150ms" 8.8.8.
 
 ![Default mode demo](assets/windows-mtr-m.gif)
 ![Enhanced mode demo](assets/windows-mtr-upscaled.gif)
+
+
+## REST API operational limits (v1 plan)
+
+If you deploy the planned REST API wrapper, apply these defaults unless you have a reviewed reason to change them:
+
+- Bind to `127.0.0.1:3000` by default
+- Require explicit opt-in for non-local bind addresses
+- Request timeout: `10s`
+- Max concurrent probes: `8`
+- Max targets per request: `8`
+- Max request body size: `16 KiB`
+
+Authentication decision for v1:
+- Local-only bind: `none-local-only` is acceptable
+- Non-local bind: require `X-API-Key` or mTLS
+
+Input validation before probe execution:
+- Hostnames/IPs normalized and validated
+- Ports validated in `1..=65535` (required for TCP/UDP)
+- Intervals/timeouts validated as positive finite numbers (`timeout >= interval`)
+
+See [docs/security/rest-api.md](docs/security/rest-api.md).

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -5,6 +5,19 @@ info:
   description: |
     Initial v1 contract for a service wrapper around windows-mtr probe/report concepts.
 
+    ## Security defaults for v1
+    - Bind address defaults to `127.0.0.1:3000`.
+    - Non-local bind (`0.0.0.0` or public/private interfaces) is disabled by default and requires explicit opt-in.
+    - Per-request timeout defaults to `10` seconds.
+    - Maximum concurrent probes defaults to `8` in-flight jobs.
+    - Maximum target count per request defaults to `8` entries.
+    - Maximum request payload defaults to `16384` bytes.
+
+    ## Authentication strategy decision (v1)
+    - **Default**: `none-local-only` when bound to loopback only.
+    - **Required for non-local bind**: `api_key` or `mTLS`.
+    - Deployments exposing the API beyond localhost MUST NOT run without authentication.
+
     ## Mapping from CLI/report concepts (`USAGE.md`)
     - Report row semantics (`Loss%`, `Snt`, `Last`, `Avg`, `Best`, `Wrst`, `StDev`) map to per-hop API fields:
       `loss_pct`, `sent`, `last_ms`, `avg_ms`, `best_ms`, `worst_ms`, `stddev_ms`.
@@ -22,6 +35,8 @@ info:
 servers:
   - url: https://example.invalid
     description: Placeholder server URL for contract documentation
+security:
+  - ApiKeyAuth: []
 paths:
   /api/v1/health:
     get:
@@ -57,6 +72,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Payload too large (abuse-prevention guard)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Request rejected by rate/concurrency limiter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/probes/{id}:
     get:
       summary: Fetch probe result status and report snapshot
@@ -87,6 +114,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: Required for non-local deployments unless mTLS is enforced by the ingress.
+    MutualTLS:
+      type: mutualTLS
+      description: Optional alternative authentication strategy for non-local deployments.
   schemas:
     EnvelopeMeta:
       type: object
@@ -166,12 +202,20 @@ components:
     CreateProbeRequestIcmp:
       type: object
       required:
-        - target
+        - targets
       properties:
-        target:
-          type: string
-          description: Hostname or IP target (maps to CLI positional target).
-          example: 1.1.1.1
+        targets:
+          type: array
+          minItems: 1
+          maxItems: 8
+          description: |
+            Hostname/IP targets to probe. All inputs are normalized and validated before execution.
+            Operational limit: at most 8 targets per request.
+          items:
+            type: string
+            minLength: 1
+            maxLength: 253
+          example: ["1.1.1.1"]
         protocol:
           type: string
           enum: [icmp]
@@ -193,18 +237,37 @@ components:
           type: boolean
           default: false
           description: Include ASN lookups when available (maps to `-b`/`-z`).
+        interval_seconds:
+          type: number
+          format: float
+          exclusiveMinimum: 0
+          description: Probe interval in seconds. Must be positive.
+        timeout_seconds:
+          type: number
+          format: float
+          exclusiveMinimum: 0
+          default: 10
+          description: Per-request timeout in seconds. Must be positive and >= `interval_seconds`.
       additionalProperties: false
     CreateProbeRequestTcpUdp:
       type: object
       required:
-        - target
+        - targets
         - protocol
         - port
       properties:
-        target:
-          type: string
-          description: Hostname or IP target (maps to CLI positional target).
-          example: 1.1.1.1
+        targets:
+          type: array
+          minItems: 1
+          maxItems: 8
+          description: |
+            Hostname/IP targets to probe. All inputs are normalized and validated before execution.
+            Operational limit: at most 8 targets per request.
+          items:
+            type: string
+            minLength: 1
+            maxLength: 253
+          example: ["1.1.1.1", "example.com"]
         protocol:
           type: string
           enum: [tcp, udp]
@@ -230,6 +293,17 @@ components:
           type: boolean
           default: false
           description: Include ASN lookups when available (maps to `-b`/`-z`).
+        interval_seconds:
+          type: number
+          format: float
+          exclusiveMinimum: 0
+          description: Probe interval in seconds. Must be positive.
+        timeout_seconds:
+          type: number
+          format: float
+          exclusiveMinimum: 0
+          default: 10
+          description: Per-request timeout in seconds. Must be positive and >= `interval_seconds`.
       additionalProperties: false
     CreateProbeData:
       type: object

--- a/docs/security/rest-api.md
+++ b/docs/security/rest-api.md
@@ -1,0 +1,90 @@
+# REST API Security Threat Model (v1)
+
+## Scope
+
+This document defines baseline security assumptions and controls for the planned windows-mtr REST API v1.
+
+## Assets
+
+- Probe execution capability (ICMP/TCP/UDP diagnostics).
+- Host and network metadata in probe requests/results.
+- Service availability for legitimate operators.
+
+## Trust boundaries
+
+- **Inbound HTTP boundary**: every request payload and header is untrusted.
+- **Network target boundary**: target hostnames/IPs/ports are attacker-controlled input.
+- **Execution boundary**: probe runtime can generate privileged network activity and must be constrained.
+
+## Authentication strategy decision (v1)
+
+1. **Default local-only mode**: `none-local-only`.
+   - Allowed only when server binds to loopback (`127.0.0.1` / `::1`).
+2. **Non-local deployments**: explicit authentication is required.
+   - Choose one of:
+     - **API key** (`X-API-Key`) for simple service-to-service deployments.
+     - **mTLS** for environments with certificate-based workload identity.
+3. **Prohibited**: non-local bind with no authentication.
+
+## Secure defaults
+
+- Bind address default: `127.0.0.1:3000`.
+- Non-local bind requires explicit opt-in.
+- Request timeout default: `10s`.
+- Max concurrent probes default: `8`.
+- Max targets per request default: `8`.
+- Max payload size default: `16KiB`.
+
+## Input validation and normalization requirements
+
+All untrusted request fields MUST be validated before probe execution:
+
+- **Hostnames/IPs**
+  - Trim surrounding whitespace.
+  - Accept canonical IP literals (IPv4/IPv6).
+  - Hostnames normalized to lowercase.
+  - Reject empty values, invalid characters, overlong labels (>63), or overlong hostnames (>253).
+- **Ports**
+  - Required for TCP/UDP probes.
+  - Integer in range `1..=65535`.
+- **Intervals/timeouts**
+  - Positive finite numbers only.
+  - `timeout_seconds >= interval_seconds` when both are present.
+
+## Abuse prevention controls
+
+- **Rate limiting**: reject request bursts above configured fixed-window limit.
+- **Concurrency limiting**: reject probe starts when in-flight probe count exceeds limit.
+- **Payload limiting**: reject oversized request bodies with 413.
+- **Target cardinality limiting**: reject requests with too many targets.
+
+## Threats and mitigations
+
+- **Unauthenticated remote use** → prevented by local-only default and non-local auth requirement.
+- **SSRF-like probing abuse** → constrained by auth, request validation, and target count limits.
+- **Resource exhaustion (CPU/socket saturation)** → constrained by timeout + concurrency + rate limits.
+- **Large-body denial attempts** → constrained by payload size cap.
+- **Input parsing edge cases** → constrained by strict normalization + explicit validation failures.
+
+## Residual risks
+
+- API key leakage in logs or process env if deployed improperly.
+- Operator misconfiguration of network ACLs around non-local deployments.
+- Legitimate but high-cost probes can still consume available concurrency budget.
+
+## Operational guidance
+
+- Keep v1 local-only unless an integration requires remote access.
+- Prefer mTLS over API keys in production.
+- Add perimeter controls (firewall/ingress allow-list) even when auth is enabled.
+- Monitor 413/429 rates for abuse or client misconfiguration.
+
+## Industry baseline alignment
+
+This v1 model aligns with common API hardening guidance:
+
+- **OWASP API Security Top 10 (2023)** emphasis on authentication, unrestricted resource consumption controls, and input validation.
+- **HTTP Semantics (RFC 9110)** status-code usage for payload and request throttling outcomes (e.g., 413/429).
+
+These references were checked during this update to ensure the guardrails match mainstream operator expectations.
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use std::env;
-use std::io::Write;
-use std::net::{IpAddr, ToSocketAddrs};
-use std::process::{self, Command, Stdio};
-use windows_mtr::passthrough::parse_passthrough_flags as parse_passthrough_flags_core;
+use std::net::IpAddr;
+use std::process;
+use windows_mtr::service::{
+    EnhancedUiConfig, JsonOutput, ProbeError, ProbeRequest, UiMode, build_probe_plan,
+    run_embedded_trippy,
+};
 
 mod error;
 mod native_ui;
@@ -166,7 +168,7 @@ impl OnOff {
     }
 }
 
-fn json_format_from_args(args: &Cli) -> Option<JsonOutput> {
+fn json_output_from_cli(args: &Cli) -> Option<JsonOutput> {
     if args.json {
         Some(JsonOutput::Compact)
     } else if args.json_pretty {
@@ -177,7 +179,7 @@ fn json_format_from_args(args: &Cli) -> Option<JsonOutput> {
 }
 
 fn should_print_banner(args: &Cli) -> bool {
-    json_format_from_args(args).is_none()
+    json_output_from_cli(args).is_none()
 }
 
 fn print_banner() {
@@ -204,19 +206,8 @@ fn enhanced_ui_config_from_cli(args: &Cli) -> EnhancedUiConfig {
     }
 }
 
-fn verify_options(args: &Cli) -> Result<()> {
-    if (args.tcp || args.udp) && args.port.is_none() {
-        let (protocol, flag) = if args.tcp { ("TCP", 'T') } else { ("UDP", 'U') };
-        return Err(MtrError::PortRequired(protocol.to_string(), flag));
-    }
-
-    if args.report_wide && !args.report && !args.json && !args.json_pretty {
-        return Err(MtrError::InvalidOption(
-            "-w/--report-wide requires -r/--report or --json output mode".to_string(),
-        ));
-    }
-
-    let has_enhanced_specific_options = args.latency_warn_ms.is_some()
+fn build_probe_request(args: &Cli) -> ProbeRequest {
+    let has_enhanced_overrides = args.latency_warn_ms.is_some()
         || args.latency_bad_ms.is_some()
         || args.loss_warn_pct.is_some()
         || args.loss_bad_pct.is_some()
@@ -224,224 +215,40 @@ fn verify_options(args: &Cli) -> Result<()> {
         || args.enhanced_sparklines.is_some()
         || args.enhanced_summary.is_some();
 
-    if (args.ui == UiPreset::Enhanced || args.ui == UiPreset::Native)
-        && (args.report || args.json || args.json_pretty)
-    {
-        let ui_name = match args.ui {
-            UiPreset::Enhanced => "enhanced",
-            UiPreset::Native => "native",
-            UiPreset::Default => "default",
-        };
-
-        return Err(MtrError::InvalidOption(format!(
-            "--ui {ui_name} is only supported in interactive TUI mode"
-        )));
-    }
-
-    if has_enhanced_specific_options && args.ui != UiPreset::Enhanced {
-        return Err(MtrError::InvalidOption(
-            "enhanced UI tuning flags require --ui enhanced".to_string(),
-        ));
-    }
-
-    if args.ui == UiPreset::Enhanced {
-        let config = EnhancedUiConfig::from_cli(args);
-        if config.latency_warn_ms >= config.latency_bad_ms {
-            return Err(MtrError::InvalidOption(
-                "--latency-warn-ms must be lower than --latency-bad-ms".to_string(),
-            ));
-        }
-        if config.loss_warn_pct >= config.loss_bad_pct {
-            return Err(MtrError::InvalidOption(
-                "--loss-warn-pct must be lower than --loss-bad-pct".to_string(),
-            ));
-        }
-    }
-
-    if let Some(flags) = &args.trippy_flags {
-        let parsed = parse_passthrough_flags(flags)?;
-        let conflicting = [
-            "--tui-latency-warn-threshold",
-            "--tui-latency-bad-threshold",
-            "--tui-loss-warn-threshold",
-            "--tui-loss-bad-threshold",
-            "--tui-row-coloring",
-            "--tui-hop-trend",
-            "--tui-summary-jitter",
-            "--tui-summary-percentiles",
-        ];
-
-        if args.ui == UiPreset::Enhanced
-            && parsed
-                .iter()
-                .any(|token| conflicting.iter().any(|flag| token == flag))
-        {
-            return Err(MtrError::InvalidOption(
-                "--trippy-flags cannot override windows-mtr enhanced UI wrapper settings"
-                    .to_string(),
-            ));
-        }
-    }
-
-    Ok(())
-}
-
-fn mode_from_args(args: &Cli) -> &'static str {
-    if json_format_from_args(args).is_some() {
-        "json"
-    } else if args.report || args.report_wide {
-        "pretty"
-    } else {
-        "tui"
+    ProbeRequest {
+        host: args.host.clone(),
+        tcp: args.tcp,
+        udp: args.udp,
+        port: args.port,
+        source_port: args.source_port,
+        report: args.report,
+        json_output: json_output_from_cli(args),
+        count: args.count,
+        interval_seconds: args.interval,
+        timeout_seconds: args.timeout,
+        report_wide: args.report_wide,
+        no_dns: args.no_dns,
+        max_hops: args.max_hops,
+        show_asn: args.show_asn,
+        dns_lookup_as_info: args.dns_lookup_as_info,
+        packet_size: args.packet_size,
+        src: args.src,
+        interface: args.interface.clone(),
+        ecmp: args.ecmp.clone(),
+        dns_cache_ttl_seconds: args.dns_cache_ttl,
+        trippy_flags: args.trippy_flags.clone(),
+        ui_mode: ui_mode_from_cli(args.ui),
+        enhanced_ui: enhanced_ui_config_from_cli(args),
+        has_enhanced_overrides,
     }
 }
 
-fn duration_seconds(value: f32) -> String {
-    if value.fract() == 0.0 {
-        format!("{}s", value as u64)
-    } else {
-        format!("{value}s")
+fn to_cli_error(error: ProbeError) -> MtrError {
+    match error {
+        ProbeError::HostResolutionError(host) => MtrError::HostResolutionError(host),
+        ProbeError::PortRequired(protocol, flag) => MtrError::PortRequired(protocol, flag),
+        ProbeError::InvalidOption(detail) => MtrError::InvalidOption(detail),
     }
-}
-
-fn parse_passthrough_flags(flags: &str) -> Result<Vec<String>> {
-    parse_passthrough_flags_core(flags).map_err(MtrError::InvalidOption)
-}
-
-fn build_embedded_trippy_args(args: &Cli, host: &str) -> Result<Vec<String>> {
-    let mut trippy_args = vec!["mtr".to_string()];
-
-    trippy_args.extend(["--mode".to_string(), mode_from_args(args).to_string()]);
-
-    if args.tcp {
-        trippy_args.push("--tcp".to_string());
-    } else if args.udp {
-        trippy_args.push("--udp".to_string());
-    }
-
-    if let Some(port) = args.port {
-        trippy_args.extend(["--target-port".to_string(), port.to_string()]);
-    }
-
-    if let Some(source_port) = args.source_port {
-        trippy_args.extend(["--source-port".to_string(), source_port.to_string()]);
-    }
-
-    if let Some(count) = args.count {
-        trippy_args.extend(["--report-cycles".to_string(), count.to_string()]);
-    }
-
-    if let Some(interval) = args.interval {
-        trippy_args.extend([
-            "--min-round-duration".to_string(),
-            duration_seconds(interval),
-        ]);
-    }
-
-    if let Some(timeout) = args.timeout {
-        trippy_args.extend(["--grace-duration".to_string(), duration_seconds(timeout)]);
-    }
-
-    if args.no_dns {
-        trippy_args.extend(["--tui-address-mode".to_string(), "ip".to_string()]);
-    }
-
-    if let Some(max_hops) = args.max_hops {
-        trippy_args.extend(["--max-ttl".to_string(), max_hops.to_string()]);
-    }
-
-    if args.show_asn || args.dns_lookup_as_info {
-        trippy_args.push("--dns-lookup-as-info".to_string());
-    }
-
-    if let Some(packet_size) = args.packet_size {
-        trippy_args.extend(["--packet-size".to_string(), packet_size.to_string()]);
-    }
-
-    if let Some(src) = args.src {
-        trippy_args.extend(["--source-address".to_string(), src.to_string()]);
-    }
-
-    if let Some(interface) = &args.interface {
-        trippy_args.extend(["--interface".to_string(), interface.clone()]);
-    }
-
-    if let Some(ecmp) = &args.ecmp {
-        trippy_args.extend(["--multipath-strategy".to_string(), ecmp.clone()]);
-    }
-
-    if let Some(ttl) = args.dns_cache_ttl {
-        trippy_args.extend(["--dns-ttl".to_string(), format!("{ttl}s")]);
-    }
-
-    if args.ui == UiPreset::Enhanced {
-        let ui = EnhancedUiConfig::from_cli(args);
-        trippy_args.extend([
-            "--tui-latency-warn-threshold".to_string(),
-            format!("{}ms", ui.latency_warn_ms),
-            "--tui-latency-bad-threshold".to_string(),
-            format!("{}ms", ui.latency_bad_ms),
-            "--tui-loss-warn-threshold".to_string(),
-            ui.loss_warn_pct.to_string(),
-            "--tui-loss-bad-threshold".to_string(),
-            ui.loss_bad_pct.to_string(),
-            "--tui-row-coloring".to_string(),
-            ui.row_coloring.to_string(),
-            "--tui-hop-trend".to_string(),
-            ui.sparklines.to_string(),
-            "--tui-summary-jitter".to_string(),
-            ui.summary.to_string(),
-            "--tui-summary-percentiles".to_string(),
-            ui.summary.to_string(),
-        ]);
-    }
-
-    if let Some(extra) = &args.trippy_flags {
-        trippy_args.extend(parse_passthrough_flags(extra)?);
-    }
-
-    trippy_args.push(host.to_string());
-    Ok(trippy_args)
-}
-
-fn run_embedded_trippy(args: &[String], json_format: Option<JsonFormat>) -> anyhow::Result<i32> {
-    // SAFETY: `current_exe` is only used to re-exec this process for output formatting,
-    // not for any trust or authorization decision.
-    let current_exe =
-        // nosemgrep: rust.lang.security.current-exe.current-exe
-        env::current_exe().context("failed to locate current executable")?;
-
-    if let Some(format) = json_format {
-        let output = Command::new(&current_exe)
-            .env(EMBEDDED_TRIPPY_ENV, "1")
-            .args(args.iter().skip(1))
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .output()
-            .context("failed to launch embedded trippy runner")?;
-
-        match format {
-            JsonFormat::Compact => {
-                let value: serde_json::Value = serde_json::from_slice(&output.stdout)
-                    .context("failed to parse trippy JSON output")?;
-                serde_json::to_writer(std::io::stdout(), &value)
-                    .context("failed to write compact JSON output")?;
-                std::io::stdout().write_all(b"\n")?;
-            }
-            JsonFormat::Pretty => {
-                std::io::stdout().write_all(&output.stdout)?;
-            }
-        }
-
-        return Ok(output.status.code().unwrap_or(2));
-    }
-
-    let status = Command::new(current_exe)
-        .env(EMBEDDED_TRIPPY_ENV, "1")
-        .args(args.iter().skip(1))
-        .status()
-        .context("failed to launch embedded trippy runner")?;
-    Ok(status.code().unwrap_or(2))
 }
 
 fn main() -> anyhow::Result<()> {
@@ -456,23 +263,13 @@ fn main() -> anyhow::Result<()> {
     }
 
     let request = build_probe_request(&args);
-    verify_options(&request)
+    let plan = build_probe_plan(&request)
         .map_err(to_cli_error)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))
+        .map_err(|error| anyhow::anyhow!(error.to_string()))
         .context("invalid command-line options")?;
 
-    let host = validate_target(&request.host)
-        .map_err(to_cli_error)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))
-        .with_context(|| format!("invalid target host: {}", request.host))?;
-
-    let trippy_args = build_embedded_trippy_args(&request, &host)
-        .map_err(to_cli_error)
-        .map_err(|e| anyhow::anyhow!(e.to_string()))
-        .context("failed to translate windows-mtr options into trippy options")?;
-
-    if args.ui == UiPreset::Native {
-        let code = native_ui::run_native_ui(&host, &trippy_args)?;
+    if plan.ui_mode == UiMode::Native {
+        let code = native_ui::run_native_ui(&plan.validated_host, &plan.trippy_args)?;
         process::exit(code);
     }
 
@@ -484,9 +281,10 @@ fn main() -> anyhow::Result<()> {
 
     let result = run_embedded_trippy(
         &current_exe,
-        &trippy_args,
-        request.json_output,
+        &plan.trippy_args,
+        plan.json_output,
         EMBEDDED_TRIPPY_ENV,
-    )?;
+    )
+    .context("failed to run embedded trippy")?;
     process::exit(result.exit_code);
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,3 +1,4 @@
+pub mod rest_api;
 use anyhow::Context;
 use std::io::Write;
 use std::net::{IpAddr, ToSocketAddrs};

--- a/src/service/rest_api.rs
+++ b/src/service/rest_api.rs
@@ -1,0 +1,509 @@
+use std::collections::HashSet;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+const MAX_HOSTNAME_LEN: usize = 253;
+const MAX_LABEL_LEN: usize = 63;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AuthStrategy {
+    ApiKey,
+    Mtls,
+    NoneLocalOnly,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ProbeProtocol {
+    Icmp,
+    Tcp,
+    Udp,
+}
+
+#[derive(Debug, Clone)]
+pub struct RestApiConfig {
+    pub bind_addr: SocketAddr,
+    pub allow_non_local_bind: bool,
+    pub auth_strategy: AuthStrategy,
+    pub request_timeout: Duration,
+    pub max_concurrent_probes: usize,
+    pub max_targets_per_request: usize,
+    pub max_payload_bytes: usize,
+}
+
+impl Default for RestApiConfig {
+    fn default() -> Self {
+        Self {
+            bind_addr: SocketAddr::from(([127, 0, 0, 1], 3000)),
+            allow_non_local_bind: false,
+            auth_strategy: AuthStrategy::NoneLocalOnly,
+            request_timeout: Duration::from_secs(10),
+            max_concurrent_probes: 8,
+            max_targets_per_request: 8,
+            max_payload_bytes: 16 * 1024,
+        }
+    }
+}
+
+impl RestApiConfig {
+    pub fn validate_security_defaults(&self) -> Result<(), RestApiValidationError> {
+        if !self.allow_non_local_bind && !self.bind_addr.ip().is_loopback() {
+            return Err(RestApiValidationError::NonLocalBindRequiresOptIn(
+                self.bind_addr,
+            ));
+        }
+
+        if self.request_timeout.is_zero() {
+            return Err(RestApiValidationError::InvalidTimeout(
+                "request_timeout must be greater than zero".to_string(),
+            ));
+        }
+
+        if self.max_concurrent_probes == 0 {
+            return Err(RestApiValidationError::InvalidConcurrencyLimit(
+                "max_concurrent_probes must be at least 1".to_string(),
+            ));
+        }
+
+        if self.max_targets_per_request == 0 {
+            return Err(RestApiValidationError::InvalidTargetLimit(
+                "max_targets_per_request must be at least 1".to_string(),
+            ));
+        }
+
+        if self.max_payload_bytes == 0 {
+            return Err(RestApiValidationError::OversizedPayload(
+                "max_payload_bytes must be at least 1".to_string(),
+            ));
+        }
+
+        if self.auth_strategy == AuthStrategy::NoneLocalOnly && !self.bind_addr.ip().is_loopback() {
+            return Err(RestApiValidationError::AuthStrategyViolation(
+                "auth_strategy=none-local-only is only valid for localhost binds".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateProbeApiRequest {
+    pub targets: Vec<String>,
+    pub protocol: ProbeProtocol,
+    pub port: Option<u16>,
+    pub interval_seconds: Option<f32>,
+    pub timeout_seconds: Option<f32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizedCreateProbeRequest {
+    pub targets: Vec<String>,
+    pub protocol: ProbeProtocol,
+    pub port: Option<u16>,
+    pub interval_seconds: Option<f32>,
+    pub timeout_seconds: Option<f32>,
+}
+
+impl CreateProbeApiRequest {
+    pub fn normalize_and_validate(
+        self,
+        config: &RestApiConfig,
+    ) -> Result<NormalizedCreateProbeRequest, RestApiValidationError> {
+        if self.targets.is_empty() {
+            return Err(RestApiValidationError::InvalidTarget(
+                "at least one target is required".to_string(),
+            ));
+        }
+
+        if self.targets.len() > config.max_targets_per_request {
+            return Err(RestApiValidationError::TooManyTargets {
+                provided: self.targets.len(),
+                limit: config.max_targets_per_request,
+            });
+        }
+
+        if matches!(self.protocol, ProbeProtocol::Tcp | ProbeProtocol::Udp) && self.port.is_none() {
+            return Err(RestApiValidationError::InvalidPort(
+                "port is required for tcp/udp probes".to_string(),
+            ));
+        }
+
+        let interval_seconds =
+            validate_optional_positive("interval_seconds", self.interval_seconds)?;
+        let timeout_seconds = validate_optional_positive("timeout_seconds", self.timeout_seconds)?;
+
+        if let (Some(interval), Some(timeout)) = (interval_seconds, timeout_seconds)
+            && timeout < interval
+        {
+            return Err(RestApiValidationError::InvalidTimeout(
+                "timeout_seconds must be greater than or equal to interval_seconds".to_string(),
+            ));
+        }
+
+        let mut normalized_targets = Vec::with_capacity(self.targets.len());
+        let mut dedupe = HashSet::with_capacity(self.targets.len());
+
+        for raw in self.targets {
+            let normalized = normalize_target(raw)?;
+            if dedupe.insert(normalized.clone()) {
+                normalized_targets.push(normalized);
+            }
+        }
+
+        Ok(NormalizedCreateProbeRequest {
+            targets: normalized_targets,
+            protocol: self.protocol,
+            port: self.port,
+            interval_seconds,
+            timeout_seconds,
+        })
+    }
+}
+
+fn validate_optional_positive(
+    field_name: &str,
+    value: Option<f32>,
+) -> Result<Option<f32>, RestApiValidationError> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+
+    if !raw.is_finite() || raw <= 0.0 {
+        return Err(RestApiValidationError::InvalidOption(format!(
+            "{field_name} must be a positive finite number"
+        )));
+    }
+
+    Ok(Some(raw))
+}
+
+fn normalize_target(raw: String) -> Result<String, RestApiValidationError> {
+    let target = raw.trim();
+    if target.is_empty() {
+        return Err(RestApiValidationError::InvalidTarget(
+            "target must not be empty".to_string(),
+        ));
+    }
+
+    if let Ok(ip) = IpAddr::from_str(target) {
+        return Ok(ip.to_string());
+    }
+
+    let lower = target.to_ascii_lowercase();
+    if lower.len() > MAX_HOSTNAME_LEN {
+        return Err(RestApiValidationError::InvalidTarget(format!(
+            "hostname exceeds {MAX_HOSTNAME_LEN} characters"
+        )));
+    }
+
+    if !is_valid_hostname(&lower) {
+        return Err(RestApiValidationError::InvalidTarget(format!(
+            "invalid hostname: {target}"
+        )));
+    }
+
+    Ok(lower)
+}
+
+fn is_valid_hostname(hostname: &str) -> bool {
+    let labels: Vec<&str> = hostname.split('.').collect();
+    if labels.is_empty() {
+        return false;
+    }
+
+    labels.iter().all(|label| {
+        if label.is_empty() || label.len() > MAX_LABEL_LEN {
+            return false;
+        }
+
+        let starts_or_ends_hyphen = label.starts_with('-') || label.ends_with('-');
+        if starts_or_ends_hyphen {
+            return false;
+        }
+
+        label
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+    })
+}
+
+pub fn validate_payload_size(
+    payload_size_bytes: usize,
+    config: &RestApiConfig,
+) -> Result<(), RestApiValidationError> {
+    if payload_size_bytes > config.max_payload_bytes {
+        return Err(RestApiValidationError::OversizedPayload(format!(
+            "payload size {} exceeds maximum {} bytes",
+            payload_size_bytes, config.max_payload_bytes
+        )));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct ProbeConcurrencyGate {
+    in_flight: AtomicUsize,
+    limit: usize,
+}
+
+impl ProbeConcurrencyGate {
+    pub fn new(limit: usize) -> Result<Self, RestApiValidationError> {
+        if limit == 0 {
+            return Err(RestApiValidationError::InvalidConcurrencyLimit(
+                "concurrency limit must be >= 1".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            in_flight: AtomicUsize::new(0),
+            limit,
+        })
+    }
+
+    pub fn try_acquire(&self) -> Result<ProbeConcurrencyPermit<'_>, RestApiValidationError> {
+        let updated = self.in_flight.fetch_add(1, Ordering::AcqRel) + 1;
+        if updated > self.limit {
+            self.in_flight.fetch_sub(1, Ordering::AcqRel);
+            return Err(RestApiValidationError::ConcurrencyLimitExceeded { limit: self.limit });
+        }
+
+        Ok(ProbeConcurrencyPermit { gate: self })
+    }
+
+    #[cfg(test)]
+    pub fn current_in_flight(&self) -> usize {
+        self.in_flight.load(Ordering::Acquire)
+    }
+}
+
+pub struct ProbeConcurrencyPermit<'a> {
+    gate: &'a ProbeConcurrencyGate,
+}
+
+impl Drop for ProbeConcurrencyPermit<'_> {
+    fn drop(&mut self) {
+        self.gate.in_flight.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+#[derive(Debug)]
+pub struct FixedWindowRateLimiter {
+    max_requests: usize,
+    window: Duration,
+    window_started_at: Instant,
+    count: usize,
+}
+
+impl FixedWindowRateLimiter {
+    pub fn new(
+        max_requests: usize,
+        window: Duration,
+        now: Instant,
+    ) -> Result<Self, RestApiValidationError> {
+        if max_requests == 0 {
+            return Err(RestApiValidationError::InvalidRateLimit(
+                "max_requests must be >= 1".to_string(),
+            ));
+        }
+
+        if window.is_zero() {
+            return Err(RestApiValidationError::InvalidRateLimit(
+                "rate limit window must be greater than zero".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            max_requests,
+            window,
+            window_started_at: now,
+            count: 0,
+        })
+    }
+
+    pub fn allow(&mut self, now: Instant) -> Result<(), RestApiValidationError> {
+        if now.duration_since(self.window_started_at) >= self.window {
+            self.window_started_at = now;
+            self.count = 0;
+        }
+
+        if self.count >= self.max_requests {
+            return Err(RestApiValidationError::RateLimitExceeded {
+                max_requests: self.max_requests,
+            });
+        }
+
+        self.count += 1;
+        Ok(())
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
+pub enum RestApiValidationError {
+    #[error("non-local bind requires explicit opt-in: {0}")]
+    NonLocalBindRequiresOptIn(SocketAddr),
+
+    #[error("invalid target: {0}")]
+    InvalidTarget(String),
+
+    #[error("invalid port: {0}")]
+    InvalidPort(String),
+
+    #[error("invalid timeout: {0}")]
+    InvalidTimeout(String),
+
+    #[error("invalid option: {0}")]
+    InvalidOption(String),
+
+    #[error("too many targets in request: provided {provided}, maximum {limit}")]
+    TooManyTargets { provided: usize, limit: usize },
+
+    #[error("payload rejected: {0}")]
+    OversizedPayload(String),
+
+    #[error("concurrency limit exceeded: max {limit} in-flight probes")]
+    ConcurrencyLimitExceeded { limit: usize },
+
+    #[error("rate limit exceeded: max {max_requests} requests per window")]
+    RateLimitExceeded { max_requests: usize },
+
+    #[error("authentication strategy violation: {0}")]
+    AuthStrategyViolation(String),
+
+    #[error("invalid concurrency limit: {0}")]
+    InvalidConcurrencyLimit(String),
+
+    #[error("invalid target limit: {0}")]
+    InvalidTargetLimit(String),
+
+    #[error("invalid rate limit: {0}")]
+    InvalidRateLimit(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secure_defaults_require_local_bind_for_no_auth() {
+        let mut config = RestApiConfig {
+            bind_addr: SocketAddr::from(([0, 0, 0, 0], 3000)),
+            ..RestApiConfig::default()
+        };
+        assert!(matches!(
+            config.validate_security_defaults(),
+            Err(RestApiValidationError::NonLocalBindRequiresOptIn(_))
+        ));
+
+        config.allow_non_local_bind = true;
+        assert!(matches!(
+            config.validate_security_defaults(),
+            Err(RestApiValidationError::AuthStrategyViolation(_))
+        ));
+
+        config.auth_strategy = AuthStrategy::ApiKey;
+        assert!(config.validate_security_defaults().is_ok());
+    }
+
+    #[test]
+    fn normalize_and_validate_targets_and_intervals() {
+        let request = CreateProbeApiRequest {
+            targets: vec![" Example.COM ".to_string(), "1.1.1.1".to_string()],
+            protocol: ProbeProtocol::Tcp,
+            port: Some(443),
+            interval_seconds: Some(1.0),
+            timeout_seconds: Some(2.0),
+        };
+
+        let normalized = request
+            .normalize_and_validate(&RestApiConfig::default())
+            .expect("request should be valid");
+
+        assert_eq!(normalized.targets, vec!["example.com", "1.1.1.1"]);
+    }
+
+    #[test]
+    fn normalize_rejects_invalid_hostname() {
+        let request = CreateProbeApiRequest {
+            targets: vec!["bad host".to_string()],
+            protocol: ProbeProtocol::Icmp,
+            port: None,
+            interval_seconds: None,
+            timeout_seconds: None,
+        };
+
+        assert!(matches!(
+            request.normalize_and_validate(&RestApiConfig::default()),
+            Err(RestApiValidationError::InvalidTarget(_))
+        ));
+    }
+
+    #[test]
+    fn oversized_payload_is_rejected() {
+        let config = RestApiConfig::default();
+        assert!(matches!(
+            validate_payload_size(config.max_payload_bytes + 1, &config),
+            Err(RestApiValidationError::OversizedPayload(_))
+        ));
+    }
+
+    #[test]
+    fn concurrency_gate_enforces_limit() {
+        let gate = ProbeConcurrencyGate::new(1).expect("valid gate");
+        let first = gate.try_acquire().expect("first acquisition should pass");
+
+        assert!(matches!(
+            gate.try_acquire(),
+            Err(RestApiValidationError::ConcurrencyLimitExceeded { .. })
+        ));
+
+        drop(first);
+        assert_eq!(gate.current_in_flight(), 0);
+        assert!(gate.try_acquire().is_ok());
+    }
+
+    #[test]
+    fn fixed_window_rate_limiter_rejects_abusive_burst() {
+        let now = Instant::now();
+        let mut limiter =
+            FixedWindowRateLimiter::new(2, Duration::from_secs(1), now).expect("valid limiter");
+
+        assert!(limiter.allow(now).is_ok());
+        assert!(limiter.allow(now).is_ok());
+        assert!(matches!(
+            limiter.allow(now),
+            Err(RestApiValidationError::RateLimitExceeded { .. })
+        ));
+
+        let next_window = now + Duration::from_secs(1);
+        assert!(limiter.allow(next_window).is_ok());
+    }
+
+    #[test]
+    fn target_limit_is_enforced() {
+        let request = CreateProbeApiRequest {
+            targets: vec![
+                "a.example.com".to_string(),
+                "b.example.com".to_string(),
+                "c.example.com".to_string(),
+                "d.example.com".to_string(),
+                "e.example.com".to_string(),
+                "f.example.com".to_string(),
+                "g.example.com".to_string(),
+                "h.example.com".to_string(),
+                "i.example.com".to_string(),
+            ],
+            protocol: ProbeProtocol::Icmp,
+            port: None,
+            interval_seconds: None,
+            timeout_seconds: None,
+        };
+
+        assert!(matches!(
+            request.normalize_and_validate(&RestApiConfig::default()),
+            Err(RestApiValidationError::TooManyTargets { .. })
+        ));
+    }
+}

--- a/tests/rest_api_security_tests.rs
+++ b/tests/rest_api_security_tests.rs
@@ -1,0 +1,136 @@
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+use windows_mtr::service::rest_api::{
+    AuthStrategy, CreateProbeApiRequest, FixedWindowRateLimiter, ProbeConcurrencyGate,
+    ProbeProtocol, RestApiConfig, RestApiValidationError, validate_payload_size,
+};
+
+#[test]
+fn default_config_binds_localhost_and_validates() {
+    let config = RestApiConfig::default();
+    assert_eq!(config.bind_addr, SocketAddr::from(([127, 0, 0, 1], 3000)));
+    assert!(config.validate_security_defaults().is_ok());
+}
+
+#[test]
+fn non_local_bind_requires_opt_in_and_auth() {
+    let mut config = RestApiConfig {
+        bind_addr: SocketAddr::from(([0, 0, 0, 0], 3000)),
+        ..RestApiConfig::default()
+    };
+
+    assert!(matches!(
+        config.validate_security_defaults(),
+        Err(RestApiValidationError::NonLocalBindRequiresOptIn(_))
+    ));
+
+    config.allow_non_local_bind = true;
+    assert!(matches!(
+        config.validate_security_defaults(),
+        Err(RestApiValidationError::AuthStrategyViolation(_))
+    ));
+
+    config.auth_strategy = AuthStrategy::ApiKey;
+    assert!(config.validate_security_defaults().is_ok());
+}
+
+#[test]
+fn request_validation_normalizes_and_deduplicates_targets() {
+    let request = CreateProbeApiRequest {
+        targets: vec![
+            " EXAMPLE.COM ".to_string(),
+            "example.com".to_string(),
+            "1.1.1.1".to_string(),
+        ],
+        protocol: ProbeProtocol::Tcp,
+        port: Some(443),
+        interval_seconds: Some(0.5),
+        timeout_seconds: Some(1.0),
+    };
+
+    let normalized = request
+        .normalize_and_validate(&RestApiConfig::default())
+        .expect("request should validate");
+
+    assert_eq!(normalized.targets, vec!["example.com", "1.1.1.1"]);
+}
+
+#[test]
+fn rejects_invalid_untrusted_inputs() {
+    let request = CreateProbeApiRequest {
+        targets: vec!["bad host".to_string()],
+        protocol: ProbeProtocol::Udp,
+        port: Some(53),
+        interval_seconds: Some(-1.0),
+        timeout_seconds: Some(0.5),
+    };
+
+    assert!(matches!(
+        request.normalize_and_validate(&RestApiConfig::default()),
+        Err(RestApiValidationError::InvalidOption(_))
+            | Err(RestApiValidationError::InvalidTarget(_))
+    ));
+}
+
+#[test]
+fn rejects_oversized_payloads() {
+    let config = RestApiConfig::default();
+    assert!(matches!(
+        validate_payload_size(config.max_payload_bytes + 1, &config),
+        Err(RestApiValidationError::OversizedPayload(_))
+    ));
+}
+
+#[test]
+fn enforces_max_concurrent_probes_limit() {
+    let gate = ProbeConcurrencyGate::new(1).expect("valid gate");
+    let first = gate.try_acquire().expect("first should pass");
+
+    assert!(matches!(
+        gate.try_acquire(),
+        Err(RestApiValidationError::ConcurrencyLimitExceeded { .. })
+    ));
+
+    drop(first);
+    assert!(gate.try_acquire().is_ok());
+}
+
+#[test]
+fn fixed_window_rate_limit_rejects_burst() {
+    let now = Instant::now();
+    let mut limiter =
+        FixedWindowRateLimiter::new(2, Duration::from_secs(1), now).expect("valid limiter");
+
+    assert!(limiter.allow(now).is_ok());
+    assert!(limiter.allow(now).is_ok());
+    assert!(matches!(
+        limiter.allow(now),
+        Err(RestApiValidationError::RateLimitExceeded { .. })
+    ));
+}
+
+#[test]
+fn rejects_too_many_targets_per_request() {
+    let request = CreateProbeApiRequest {
+        targets: vec![
+            "a.example.com".to_string(),
+            "b.example.com".to_string(),
+            "c.example.com".to_string(),
+            "d.example.com".to_string(),
+            "e.example.com".to_string(),
+            "f.example.com".to_string(),
+            "g.example.com".to_string(),
+            "h.example.com".to_string(),
+            "i.example.com".to_string(),
+        ],
+        protocol: ProbeProtocol::Icmp,
+        port: None,
+        interval_seconds: None,
+        timeout_seconds: None,
+    };
+
+    assert!(matches!(
+        request.normalize_and_validate(&RestApiConfig::default()),
+        Err(RestApiValidationError::TooManyTargets { .. })
+    ));
+}


### PR DESCRIPTION
### Motivation

- Provide a secure, opinionated v1 baseline for a planned windows-mtr REST API including bind/auth defaults and operational limits to reduce abuse risk. 
- Centralize probe request validation, normalization and operational guards so CLI and future server wrappers share one implementation.
- Surface these defaults in docs and OpenAPI so operators and integrators have a clear contract.

### Description

- Added a new `src/service/rest_api.rs` module implementing `RestApiConfig`, validation (`validate_security_defaults`), `CreateProbeApiRequest` normalization, payload-size checks, a `ProbeConcurrencyGate`, and a `FixedWindowRateLimiter`, plus a `RestApiValidationError` error type and unit tests. 
- Refactored `src/main.rs` to build a `ProbeRequest` and use `service::build_probe_plan`/`run_embedded_trippy` outputs (validated host and trippy args) instead of ad-hoc CLI-only validation and trippy argument construction. 
- Updated library exports in `src/service/mod.rs` and added `rest_api` to the service surface. 
- Updated API contract and docs: extended `docs/api/openapi.yaml` with security/limits and request schema changes (multi-target `targets`, interval/timeout fields, 413/429 responses), added `docs/security/rest-api.md`, and added README/USAGE notes describing REST API security and operational limits. 
- Added integration-style tests under `tests/rest_api_security_tests.rs` that exercise config defaults, normalization, concurrency and rate-limiter behavior.

### Testing

- Ran unit tests in the REST API module (`src/service/rest_api.rs`) which exercised normalization, hostname validation, payload limits, concurrency gate and rate limiter, and they passed. 
- Ran the added integration tests in `tests/rest_api_security_tests.rs` which validated default config, non-local-bind/auth checks, request normalization/dedupe, input rejection, payload and target limits, concurrency and rate-limiter behavior, and they passed. 
- Executed the full test suite (`cargo test`) and the new tests succeeded without regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56e234b108330b31cc15a1dc153f6)