### PR TITLE
Align GitHub release notes with auto-labeler labels

### DIFF
--- a/.github/label-definitions.yml
+++ b/.github/label-definitions.yml
@@ -1,0 +1,51 @@
+# Canonical label catalog for this repository.
+# Keep this file in sync with:
+# - .github/labeler.yml (path-based auto-labeler)
+# - .github/workflows/pr-auto-labeler.yml (title-prefix auto-labeler)
+# - .github/release.yml (auto-generated release notes categories)
+
+labels:
+  # Path-based labels (.github/labeler.yml)
+  path_based:
+    - ci
+    - documentation
+    - rust
+    - tests
+    - packaging
+    - xtask
+    - assets
+
+  # Title-prefix labels (.github/workflows/pr-auto-labeler.yml)
+  title_prefix:
+    - enhancement
+    - bug
+    - hotfix
+    - documentation
+    - ci
+    - security
+    - performance
+    - infrastructure
+    - docker
+    - frontend
+    - patch
+    - release
+
+  # Union of labels currently applied by auto-labeler CI.
+  all:
+    - assets
+    - bug
+    - ci
+    - docker
+    - documentation
+    - enhancement
+    - frontend
+    - hotfix
+    - infrastructure
+    - packaging
+    - patch
+    - performance
+    - release
+    - rust
+    - security
+    - tests
+    - xtask

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,4 @@
+## Keep label names aligned with .github/label-definitions.yml and .github/release.yml.
 ci:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,74 @@
+# =============================================================================
+# Auto-generated release notes configuration
+# =============================================================================
+# Controls how GitHub groups merged PRs in automatically generated changelogs.
+# Used by GitHub Releases and by `gh release create --generate-notes`.
+#
+# Label source of truth:
+#   .github/label-definitions.yml
+#
+# Docs:
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+# =============================================================================
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - skip-changelog
+      - dependencies
+    authors:
+      - dependabot
+      - dependabot[bot]
+
+  categories:
+    - title: "🚀 Features & Improvements"
+      labels:
+        - enhancement
+        - performance
+
+    - title: "🐛 Fixes"
+      labels:
+        - bug
+        - hotfix
+        - patch
+
+    - title: "🔐 Security"
+      labels:
+        - security
+
+    - title: "🧱 Core Rust / Engine"
+      labels:
+        - rust
+
+    - title: "🧪 Tests"
+      labels:
+        - tests
+
+    - title: "🏗️ CI / Infrastructure / Release"
+      labels:
+        - ci
+        - infrastructure
+        - release
+
+    - title: "📦 Packaging / Docker"
+      labels:
+        - packaging
+        - docker
+
+    - title: "🖥️ Frontend / Assets"
+      labels:
+        - frontend
+        - assets
+
+    - title: "🛠️ Project Tooling"
+      labels:
+        - xtask
+
+    - title: "📚 Documentation"
+      labels:
+        - documentation
+
+    - title: "🔧 Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -16,6 +16,8 @@ permissions:
   contents: read
   pull-requests: write
 
+# Keep workflow label mappings aligned with .github/label-definitions.yml and .github/release.yml.
+
 jobs:
   label-by-path:
     name: Label by changed files


### PR DESCRIPTION
### Motivation
- Prevent drift between CI auto-labeling and release-note grouping by centralizing label definitions. 
- Provide a single, reviewable source of truth so auto-labeler workflows and GitHub generated changelogs remain consistent.

### Description
- Added ` .github/release.yml` to configure GitHub auto-generated release notes and map repository labels into human-friendly categories. 
- Added ` .github/label-definitions.yml` as a canonical catalog listing `path_based`, `title_prefix`, and the union (`all`) of labels used by auto-labeler CI. 
- Annotated ` .github/labeler.yml` and ` .github/workflows/pr-auto-labeler.yml` with sync comments to indicate they should be kept aligned with the shared label catalog and release configuration. 

### Testing
- Ran `git diff --check` to validate patch formatting and it completed without errors. 
- Ran a short Python sanity check that verified the touched YAML files are present and non-empty using a script similar to `python - <<'PY' ... PY`, and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58069d8f483308cb3409ae955fef8)