### PR TITLE
Centralize label taxonomy and enable dynamic PR auto-labeling with release notes config

### DIFF
--- a/.github/label-taxonomy.yml
+++ b/.github/label-taxonomy.yml
@@ -1,0 +1,53 @@
+title_prefix_to_labels:
+  feat: [enhancement]
+  feature: [enhancement]
+  fix: [bug]
+  bugfix: [bug]
+  hotfix: [hotfix, bug]
+  docs: [documentation]
+  ci: [ci]
+  security: [security]
+  perf: [performance]
+  build: [infrastructure]
+  docker: [docker]
+  frontend: [frontend]
+  forntend: [frontend]
+  patch: [patch]
+  release: [release]
+
+path_labels:
+  - ci
+  - documentation
+  - rust
+  - tests
+  - packaging
+  - xtask
+  - assets
+
+release_notes_categories:
+  - title: "🚀 New Features"
+    labels: [enhancement]
+  - title: "🐛 Bug Fixes"
+    labels: [bug, hotfix, patch]
+  - title: "⚡ Performance"
+    labels: [performance]
+  - title: "🔒 Security"
+    labels: [security]
+  - title: "🏗️ Infrastructure & CI"
+    labels: [ci, infrastructure, release]
+  - title: "📦 Packaging & Distribution"
+    labels: [packaging, docker]
+  - title: "📚 Documentation"
+    labels: [documentation]
+  - title: "🧪 Testing"
+    labels: [tests]
+  - title: "🦀 Core Rust"
+    labels: [rust]
+  - title: "🛠️ Tooling"
+    labels: [xtask]
+  - title: "🖥️ Frontend"
+    labels: [frontend]
+  - title: "🎨 Assets"
+    labels: [assets]
+  - title: "🔧 Other Changes"
+    labels: ["*"]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,77 @@
+# =============================================================================
+# Auto-generated release notes configuration
+# =============================================================================
+# Controls how GitHub groups merged PRs in automatically generated changelogs.
+# Used when `gh release create --generate-notes` targets this repository.
+#
+# Keep labels aligned with `.github/label-taxonomy.yml` to avoid drift.
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+# =============================================================================
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - dependencies
+      - skip-changelog
+    authors:
+      - dependabot
+      - dependabot[bot]
+
+  categories:
+    - title: "🚀 New Features"
+      labels:
+        - enhancement
+
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+        - hotfix
+        - patch
+
+    - title: "⚡ Performance"
+      labels:
+        - performance
+
+    - title: "🔒 Security"
+      labels:
+        - security
+
+    - title: "🏗️ Infrastructure & CI"
+      labels:
+        - ci
+        - infrastructure
+        - release
+
+    - title: "📦 Packaging & Distribution"
+      labels:
+        - packaging
+        - docker
+
+    - title: "📚 Documentation"
+      labels:
+        - documentation
+
+    - title: "🧪 Testing"
+      labels:
+        - tests
+
+    - title: "🦀 Core Rust"
+      labels:
+        - rust
+
+    - title: "🛠️ Tooling"
+      labels:
+        - xtask
+
+    - title: "🖥️ Frontend"
+      labels:
+        - frontend
+
+    - title: "🎨 Assets"
+      labels:
+        - assets
+
+    - title: "🔧 Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -42,59 +42,19 @@ jobs:
           echo "PR title: $PR_TITLE"
           echo "Detected prefix: '$PREFIX'"
 
-          LABEL=""
-          LABELS=""
+          LABELS=$(PREFIX_VALUE="$PREFIX" ruby -ryaml -e '
+            prefix = ENV.fetch("PREFIX_VALUE", "").strip.downcase
+            taxonomy = YAML.load_file(".github/label-taxonomy.yml")
+            labels = taxonomy.fetch("title_prefix_to_labels", {}).fetch(prefix, [])
+            puts labels.join(" ")
+          ')
 
-          case "$PREFIX" in
-            feat|feature)
-              LABEL="enhancement"
-              ;;
-            fix|bugfix)
-              LABEL="bug"
-              ;;
-            hotfix)
-              LABELS="hotfix bug"
-              ;;
-            docs)
-              LABEL="documentation"
-              ;;
-            ci)
-              LABEL="ci"
-              ;;
-            security)
-              LABEL="security"
-              ;;
-            perf)
-              LABEL="performance"
-              ;;
-            build)
-              LABEL="infrastructure"
-              ;;
-            docker)
-              LABEL="docker"
-              ;;
-            frontend|forntend)
-              LABEL="frontend"
-              ;;
-            patch)
-              LABEL="patch"
-              ;;
-            release)
-              LABEL="release"
-              ;;
-            *)
-              echo "No label mapping for prefix '${PREFIX}' — skipping."
-              exit 0
-              ;;
-          esac
-
-          LABELS=${LABELS:-$LABEL}
           if [ -z "$LABELS" ]; then
-            echo "::warning::No labels resolved for prefix '$PREFIX' — skipping."
+            echo "No label mapping for prefix '${PREFIX}' — skipping."
             exit 0
           fi
 
-          echo "Applying label(s) '$LABELS' based on prefix '$PREFIX'..."
+          echo "Applying label(s) '$LABELS' based on prefix '$PREFIX' from .github/label-taxonomy.yml..."
           read -r -a LABEL_ARRAY <<< "$LABELS"
           for label in "${LABEL_ARRAY[@]}"; do
             gh pr edit "$PR_NUMBER" \

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Windows MTR is built with enterprise-level security practices:
 - 🧪 Comprehensive fuzzing with 1000+ malformed packet tests
 - 🔑 Cryptographically signed releases with SHA-256 verification
 
-
 ### REST API security and operational limits (v1 plan)
 
 For planned REST API deployments, the security baseline is:

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,7 +137,6 @@ mtr --trippy-flags "--log-format json --verbose --tui-refresh-rate 150ms" 8.8.8.
 ![Default mode demo](assets/windows-mtr-m.gif)
 ![Enhanced mode demo](assets/windows-mtr-upscaled.gif)
 
-
 ## REST API operational limits (v1 plan)
 
 If you deploy the planned REST API wrapper, apply these defaults unless you have a reviewed reason to change them:


### PR DESCRIPTION
### Motivation
- Centralize PR title-to-label mappings and release-note categories to avoid hardcoded logic in workflows and to keep labeling and changelog generation consistent.
- Enable the auto-labeler to read mappings from a single source of truth so new prefixes can be added without editing shell logic.
- Provide a release notes configuration that aligns with the label taxonomy for `gh release` auto-generated changelogs.

### Description
- Add `.github/label-taxonomy.yml` with `title_prefix_to_labels`, `path_labels`, and `release_notes_categories` to serve as the single source of truth for label mappings and changelog grouping.
- Add `.github/release.yml` to configure categories and exclusions used by `gh release create --generate-notes` for automated release notes.
- Update `.github/workflows/pr-auto-labeler.yml` to replace the hardcoded `case` mapping with a dynamic lookup that loads labels from `.github/label-taxonomy.yml` via a small Ruby snippet and then applies labels using `gh pr edit`.
- Make minor documentation whitespace/formatting cleanups in `README.md` and `USAGE.md`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58069d8f483308cb3409ae955fef8)