### PR TITLE
Add API contract/integration CI job, OpenAPI compatibility check, and API tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ on:
       - 'Dockerfile'
       - '.github/workflows/ci.yml'
       - 'docs/probe-parity.md'
+      - 'docs/api/openapi.yaml'
+      - 'scripts/check_openapi_compat.sh'
   pull_request:
     branches: [ master ]
     paths:
@@ -32,6 +34,8 @@ on:
       - 'Dockerfile'
       - '.github/workflows/ci.yml'
       - 'docs/probe-parity.md'
+      - 'docs/api/openapi.yaml'
+      - 'scripts/check_openapi_compat.sh'
 permissions:
   contents: read
 
@@ -258,6 +262,51 @@ jobs:
           else
             echo "Probe parity summary file was not generated." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+
+  api-contract-and-integration:
+    name: API contract + integration
+    runs-on: ubuntu-latest
+    needs: pre-commit
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run API contract tests
+        run: cargo test --test api_contract_tests -- --nocapture
+        env:
+          CARGO_INCREMENTAL: 0
+
+      - name: Run API integration tests
+        run: cargo test --test api_integration_tests -- --nocapture
+        env:
+          CARGO_INCREMENTAL: 0
+
+      - name: Verify OpenAPI compatibility (breaking changes require version bump)
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_ref="${{ github.base_ref }}"
+          else
+            base_ref="master"
+          fi
+
+          ./scripts/check_openapi_compat.sh "${base_ref}"
 
 
   docker-build-amd64:

--- a/README.md
+++ b/README.md
@@ -345,6 +345,20 @@ pre-commit run --all-files
 
 Before running local pre-commit hooks, install Rust via [rustup](https://www.rust-lang.org/tools/install) and make sure `cargo` is available on your `PATH`.
 
+### Local API verification workflow
+
+To validate API behavior and schema compatibility locally, run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --test api_contract_tests -- --nocapture
+cargo test --test api_integration_tests -- --nocapture
+./scripts/check_openapi_compat.sh master
+```
+
+`check_openapi_compat.sh` resolves `origin/<base-ref>` first, then local `<base-ref>`, then `HEAD~1` as a local fallback. It requires a local Docker engine and you can pin a different `oasdiff` image via `OASDIFF_IMAGE=<image:tag>`.
+
 For any workflow change, pin each GitHub Actions `uses:` reference to a full 40-character commit SHA (avoid mutable tags/branches).
 
 ## 📜 License

--- a/scripts/check_openapi_compat.sh
+++ b/scripts/check_openapi_compat.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF=${1:-}
+HEAD_SPEC=${2:-docs/api/openapi.yaml}
+OASDIFF_IMAGE=${OASDIFF_IMAGE:-tufin/oasdiff:v1.12.0}
+
+if [[ -z "${BASE_REF}" ]]; then
+  echo "Usage: $0 <base-ref> [head-spec-path]" >&2
+  exit 2
+fi
+
+if [[ ! -f "${HEAD_SPEC}" ]]; then
+  echo "Missing head OpenAPI spec at ${HEAD_SPEC}" >&2
+  exit 2
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required to run OpenAPI compatibility checks. Install docker or run this check in CI." >&2
+  exit 2
+fi
+
+resolve_base_ref() {
+  local requested_ref=$1
+
+  if git rev-parse --verify "origin/${requested_ref}" >/dev/null 2>&1; then
+    printf 'origin/%s\n' "${requested_ref}"
+    return 0
+  fi
+
+  if git rev-parse --verify "${requested_ref}" >/dev/null 2>&1; then
+    printf '%s\n' "${requested_ref}"
+    return 0
+  fi
+
+  if git rev-parse --verify "HEAD~1" >/dev/null 2>&1; then
+    echo "warning: could not resolve ${requested_ref} or origin/${requested_ref}; falling back to HEAD~1" >&2
+    printf 'HEAD~1\n'
+    return 0
+  fi
+
+  echo "Unable to resolve base reference '${requested_ref}' or fallback 'HEAD~1'." >&2
+  exit 2
+}
+
+BASE_RESOLVED_REF=$(resolve_base_ref "${BASE_REF}")
+
+base_spec=".openapi-base-${BASE_RESOLVED_REF//\//-}.yaml"
+trap 'rm -f "${base_spec}"' EXIT
+
+git show "${BASE_RESOLVED_REF}:docs/api/openapi.yaml" > "${base_spec}"
+
+extract_version() {
+  local file=$1
+  awk '
+    /^info:[[:space:]]*$/ { in_info=1; next }
+    in_info && /^[^[:space:]]/ { in_info=0 }
+    in_info && /^[[:space:]]*version:[[:space:]]*/ {
+      value=$0
+      sub(/^[[:space:]]*version:[[:space:]]*/, "", value)
+      gsub(/^["\x27]|["\x27]$/, "", value)
+      print value
+      exit
+    }
+  ' "$file"
+}
+
+base_version=$(extract_version "${base_spec}")
+head_version=$(extract_version "${HEAD_SPEC}")
+
+if [[ -z "${base_version}" || -z "${head_version}" ]]; then
+  echo "Failed to parse OpenAPI info.version from base or head specification." >&2
+  exit 2
+fi
+
+set +e
+docker run --rm -v "${PWD}:/work" "${OASDIFF_IMAGE}" \
+  breaking "/work/${base_spec}" "/work/${HEAD_SPEC}"
+status=$?
+set -e
+
+if [[ ${status} -eq 0 ]]; then
+  echo "No breaking OpenAPI changes detected against ${BASE_RESOLVED_REF}."
+  exit 0
+fi
+
+if [[ "${base_version}" == "${head_version}" ]]; then
+  echo "Breaking OpenAPI changes detected, but API version was not bumped (${head_version})." >&2
+  exit 1
+fi
+
+echo "Breaking OpenAPI changes detected and version changed (${base_version} -> ${head_version}); allowing." >&2
+exit 0

--- a/tests/api_integration_tests.rs
+++ b/tests/api_integration_tests.rs
@@ -1,0 +1,122 @@
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+use windows_mtr::service::rest_api::{
+    CreateProbeApiRequest, ProbeConcurrencyGate, ProbeProtocol, RestApiConfig,
+    RestApiValidationError,
+};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ApiProbeRunOutcome {
+    Completed,
+    TimedOut,
+    Cancelled,
+}
+
+fn run_probe_with_timeout_and_cancel(
+    timeout: Duration,
+    cancel_rx: mpsc::Receiver<()>,
+    complete_rx: mpsc::Receiver<()>,
+) -> ApiProbeRunOutcome {
+    match complete_rx.recv_timeout(timeout) {
+        Ok(()) => ApiProbeRunOutcome::Completed,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            if cancel_rx.try_recv().is_ok() {
+                ApiProbeRunOutcome::Cancelled
+            } else {
+                ApiProbeRunOutcome::TimedOut
+            }
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => ApiProbeRunOutcome::Cancelled,
+    }
+}
+
+#[test]
+fn api_happy_path_accepts_valid_request_and_completes_before_timeout() {
+    let config = RestApiConfig::default();
+
+    let request = CreateProbeApiRequest {
+        targets: vec![" Example.COM ".to_string(), "1.1.1.1".to_string()],
+        protocol: ProbeProtocol::Tcp,
+        port: Some(443),
+        interval_seconds: Some(0.5),
+        timeout_seconds: Some(1.0),
+    };
+
+    let normalized = request
+        .normalize_and_validate(&config)
+        .expect("valid request should normalize");
+
+    assert_eq!(normalized.targets, vec!["example.com", "1.1.1.1"]);
+    assert_eq!(normalized.port, Some(443));
+
+    let (_cancel_tx, cancel_rx) = mpsc::channel();
+    let (complete_tx, complete_rx) = mpsc::channel();
+    complete_tx
+        .send(())
+        .expect("probe completion signal should send");
+
+    let outcome = run_probe_with_timeout_and_cancel(config.request_timeout, cancel_rx, complete_rx);
+    assert_eq!(outcome, ApiProbeRunOutcome::Completed);
+}
+
+#[test]
+fn api_validation_errors_reject_invalid_payload() {
+    let config = RestApiConfig::default();
+
+    let request = CreateProbeApiRequest {
+        targets: vec!["bad host".to_string()],
+        protocol: ProbeProtocol::Udp,
+        port: None,
+        interval_seconds: Some(-0.1),
+        timeout_seconds: Some(0.05),
+    };
+
+    assert!(matches!(
+        request.normalize_and_validate(&config),
+        Err(RestApiValidationError::InvalidTarget(_))
+            | Err(RestApiValidationError::InvalidPort(_))
+            | Err(RestApiValidationError::InvalidOption(_))
+    ));
+}
+
+#[test]
+fn api_timeout_path_returns_timed_out_outcome() {
+    let config = RestApiConfig {
+        request_timeout: Duration::from_millis(10),
+        ..RestApiConfig::default()
+    };
+
+    let (_cancel_tx, cancel_rx) = mpsc::channel();
+    let (_complete_tx, complete_rx) = mpsc::channel::<()>();
+
+    let outcome = run_probe_with_timeout_and_cancel(config.request_timeout, cancel_rx, complete_rx);
+    assert_eq!(outcome, ApiProbeRunOutcome::TimedOut);
+}
+
+#[test]
+fn api_cancellation_releases_concurrency_slot_for_follow_up_request() {
+    let gate = ProbeConcurrencyGate::new(1).expect("gate should initialize");
+
+    let permit = gate.try_acquire().expect("first request acquires slot");
+    assert!(matches!(
+        gate.try_acquire(),
+        Err(RestApiValidationError::ConcurrencyLimitExceeded { .. })
+    ));
+
+    let (cancel_tx, cancel_rx) = mpsc::channel();
+    let (_complete_tx, complete_rx) = mpsc::channel::<()>();
+    let timeout = Duration::from_millis(20);
+
+    let handle = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(5));
+        cancel_tx.send(()).expect("cancellation signal should send");
+    });
+
+    let outcome = run_probe_with_timeout_and_cancel(timeout, cancel_rx, complete_rx);
+    handle.join().expect("canceller thread should join");
+    assert_eq!(outcome, ApiProbeRunOutcome::Cancelled);
+
+    drop(permit);
+    assert!(gate.try_acquire().is_ok());
+}


### PR DESCRIPTION
### Motivation

- Enforce API stability and catch breaking changes by adding automated OpenAPI compatibility checks and dedicated API test lanes in CI.
- Provide a local workflow for contributors to validate formatting, lints, API contract and integration behavior before submitting changes.

### Description

- Added a new `api-contract-and-integration` GitHub Actions job that runs `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --test api_contract_tests -- --nocapture`, and `cargo test --test api_integration_tests -- --nocapture` and verifies OpenAPI compatibility via a script.
- Introduced `scripts/check_openapi_compat.sh` which resolves a base ref, extracts `info.version` from OpenAPI specs, runs `tufin/oasdiff` in Docker to detect breaking changes, and requires a version bump when breaking changes are found.
- Added `tests/api_integration_tests.rs` with several API-focused integration/unit tests covering request normalization, validation errors, timeout behavior, and concurrency/cancellation semantics.
- Updated workflow path filters to trigger CI on changes to `docs/api/openapi.yaml` and `scripts/check_openapi_compat.sh`, and added a short README section describing the local API verification workflow and usage of `check_openapi_compat.sh`.

### Testing

- No automated test runs are included in this patch snapshot; CI is updated to run `cargo fmt`, `cargo clippy`, `cargo test --test api_contract_tests`, and `cargo test --test api_integration_tests` as part of the new job.
- The OpenAPI compatibility check is implemented to run `docker` with the `tufin/oasdiff` image and will fail CI on breaking changes unless `info.version` is bumped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b57f0aa530833083c246707860af54)