### PR TITLE
Align API errors on RFC 9457 problem details shape

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -138,17 +138,38 @@ components:
           type: string
           description: Correlation identifier for tracing/logging.
       additionalProperties: false
-    ApiError:
+    ApiProblemDetails:
       type: object
       required:
+        - type
+        - title
+        - status
+        - detail
         - code
-        - message
       properties:
+        type:
+          type: string
+          format: uri
+          description: Canonical URI identifying the problem class.
+          example: https://windows-mtr.dev/problems/invalid-target
+        title:
+          type: string
+          description: Short human-readable summary.
+          example: Invalid target
+        status:
+          type: integer
+          minimum: 100
+          maximum: 599
+          description: HTTP status code for this occurrence.
+          example: 400
+        detail:
+          type: string
+          description: Human-readable detail specific to this occurrence.
+          example: Failed to resolve host: invalid host
         code:
           type: string
-          example: invalid_request
-        message:
-          type: string
+          description: Stable machine-readable project error code.
+          example: invalid_target
       additionalProperties: false
     ErrorResponse:
       type: object
@@ -159,7 +180,17 @@ components:
         meta:
           $ref: '#/components/schemas/EnvelopeMeta'
         error:
-          $ref: '#/components/schemas/ApiError'
+          $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        meta:
+          schema_version: v1
+          request_id: req-7f98
+        error:
+          type: https://windows-mtr.dev/problems/invalid-target
+          title: Invalid target
+          status: 400
+          detail: Failed to resolve host: invalid host
+          code: invalid_target
       additionalProperties: false
     HealthData:
       type: object

--- a/src/api_error.rs
+++ b/src/api_error.rs
@@ -20,7 +20,16 @@ pub struct ApiError {
 /// JSON envelope returned for API failures.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct ApiErrorResponse {
+    pub meta: ApiResponseMeta,
     pub error: ApiProblemDetails,
+}
+
+/// Shared response metadata envelope for versioning/correlation.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct ApiResponseMeta {
+    pub schema_version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
 }
 
 /// RFC 9457 style problem details with a project-specific machine code.
@@ -65,6 +74,10 @@ impl ApiError {
 
     pub fn response(&self) -> ApiErrorResponse {
         ApiErrorResponse {
+            meta: ApiResponseMeta {
+                schema_version: "v1",
+                request_id: None,
+            },
             error: ApiProblemDetails {
                 type_url: Self::problem_type(self.code),
                 title: self.title,
@@ -266,6 +279,8 @@ mod tests {
         assert_eq!(api_error.code, "probe_execution_failed");
 
         let body = api_error.response();
+        assert_eq!(body.meta.schema_version, "v1");
+        assert_eq!(body.meta.request_id, None);
         assert_eq!(body.error.status, 502);
         assert_eq!(body.error.code, "probe_execution_failed");
         assert_eq!(

--- a/tests/api_contract_tests.rs
+++ b/tests/api_contract_tests.rs
@@ -52,6 +52,20 @@ fn required_property_names(schema: &Value) -> Vec<String> {
         .collect()
 }
 
+fn property_names(schema: &Value) -> Vec<String> {
+    let schema_map = as_mapping(schema);
+    let properties = as_mapping(map_get(schema_map, "properties"));
+
+    properties
+        .keys()
+        .map(|item| {
+            item.as_str()
+                .expect("property entries should be strings")
+                .to_string()
+        })
+        .collect()
+}
+
 fn schema_ref_at_operation_response(
     paths: &Mapping,
     path: &str,
@@ -168,6 +182,40 @@ fn openapi_contract_uses_envelope_across_success_and_error() {
         schema_ref_at_operation_response(paths, "/api/v1/probes/{id}", "get", "404"),
         "#/components/schemas/ErrorResponse"
     );
+}
+
+#[test]
+fn openapi_contract_documents_error_shape_fields_and_required() {
+    let openapi = load_openapi();
+    let openapi_map = as_mapping(&openapi);
+    let components = as_mapping(map_get(openapi_map, "components"));
+    let schemas = as_mapping(map_get(components, "schemas"));
+
+    let error_response_required = required_property_names(map_get(schemas, "ErrorResponse"));
+    assert!(
+        error_response_required.iter().any(|field| field == "meta"),
+        "ErrorResponse must require meta"
+    );
+    assert!(
+        error_response_required.iter().any(|field| field == "error"),
+        "ErrorResponse must require error"
+    );
+
+    let error_required = required_property_names(map_get(schemas, "ApiProblemDetails"));
+    for required in ["type", "title", "status", "detail", "code"] {
+        assert!(
+            error_required.iter().any(|field| field == required),
+            "ApiProblemDetails.required must contain {required}"
+        );
+    }
+
+    let error_properties = property_names(map_get(schemas, "ApiProblemDetails"));
+    for property in ["type", "title", "status", "detail", "code"] {
+        assert!(
+            error_properties.iter().any(|field| field == property),
+            "ApiProblemDetails.properties must contain {property}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- The OpenAPI docs and runtime error shape had drifted: docs used a simple `{code,message}` shape while runtime emitted RFC 9457-style problem details, causing contract mismatch.
- Choose a single canonical, machine-readable error shape that supports human detail and stable error codes plus envelope metadata for versioning/correlation.

### Description
- Adopted RFC 9457-style problem details as the canonical error payload by adding `ApiProblemDetails` (`type`, `title`, `status`, `detail`, `code`) and replacing the old schema in `docs/api/openapi.yaml`.
- Kept and formalized envelope metadata by adding `meta.schema_version` (always `v1`) and optional `meta.request_id` to `ErrorResponse` and the runtime `ApiErrorResponse`.
- Updated runtime serialization in `src/api_error.rs` so `ApiErrorResponse` includes `meta` and the RFC-style `error`, and set `meta.request_id` to `None` when unavailable.
- Extended `tests/api_contract_tests.rs` to assert actual error field names and required properties for `ErrorResponse` and `ApiProblemDetails` (not only `$ref` usage), and added a runtime assertion in `src/api_error.rs` tests verifying `meta.schema_version` and `request_id` behavior.

### Testing
- Ran `cargo fmt --all -- --check` which passed in this environment.
- Attempted `cargo clippy --all-targets --all-features -- -D warnings` but it was blocked by the environment `rustc` version (`1.87.0`) while the project and dependencies require `>=1.88.0`.
- Attempted `cargo test --all` but it was similarly blocked by the `rustc` version mismatch and could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e3dd3664833095940565dca93cb4)