### PR TITLE
Bring REST create-probe Rust DTOs into OpenAPI v1 parity

### DIFF
--- a/src/service/api_models.rs
+++ b/src/service/api_models.rs
@@ -3,16 +3,20 @@ use serde::{Deserialize, Serialize};
 use crate::service::rest_api::{CreateProbeApiRequest, ProbeProtocol};
 use crate::service::rest_server::{ProbeExecutionResult, ProbeJob, ProbeJobStatus};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CreateProbeRequestDto {
     pub targets: Vec<String>,
     pub protocol: ApiProbeProtocol,
     pub port: Option<u16>,
+    pub count: Option<usize>,
+    pub max_hops: Option<u16>,
+    pub resolve_dns: Option<bool>,
+    pub include_asn: Option<bool>,
     pub interval_seconds: Option<f32>,
     pub timeout_seconds: Option<f32>,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ApiProbeProtocol {
     Icmp,
@@ -36,6 +40,10 @@ impl From<CreateProbeRequestDto> for CreateProbeApiRequest {
             targets: value.targets,
             protocol: value.protocol.into(),
             port: value.port,
+            count: value.count,
+            max_hops: value.max_hops,
+            resolve_dns: value.resolve_dns,
+            include_asn: value.include_asn,
             interval_seconds: value.interval_seconds,
             timeout_seconds: value.timeout_seconds,
         }

--- a/src/service/rest_api.rs
+++ b/src/service/rest_api.rs
@@ -93,6 +93,10 @@ pub struct CreateProbeApiRequest {
     pub targets: Vec<String>,
     pub protocol: ProbeProtocol,
     pub port: Option<u16>,
+    pub count: Option<usize>,
+    pub max_hops: Option<u16>,
+    pub resolve_dns: Option<bool>,
+    pub include_asn: Option<bool>,
     pub interval_seconds: Option<f32>,
     pub timeout_seconds: Option<f32>,
 }
@@ -102,6 +106,10 @@ pub struct NormalizedCreateProbeRequest {
     pub targets: Vec<String>,
     pub protocol: ProbeProtocol,
     pub port: Option<u16>,
+    pub count: Option<usize>,
+    pub max_hops: Option<u8>,
+    pub resolve_dns: bool,
+    pub include_asn: bool,
     pub interval_seconds: Option<f32>,
     pub timeout_seconds: Option<f32>,
 }
@@ -130,6 +138,17 @@ impl CreateProbeApiRequest {
             ));
         }
 
+        if self.port == Some(0) {
+            return Err(RestApiValidationError::InvalidPort(
+                "port must be between 1 and 65535".to_string(),
+            ));
+        }
+
+        let count = validate_optional_count(self.count)?;
+        let max_hops = validate_optional_max_hops(self.max_hops)?;
+        let resolve_dns = self.resolve_dns.unwrap_or(true);
+        let include_asn = self.include_asn.unwrap_or(false);
+
         let interval_seconds =
             validate_optional_positive("interval_seconds", self.interval_seconds)?;
         let timeout_seconds = validate_optional_positive("timeout_seconds", self.timeout_seconds)?;
@@ -156,10 +175,42 @@ impl CreateProbeApiRequest {
             targets: normalized_targets,
             protocol: self.protocol,
             port: self.port,
+            count,
+            max_hops,
+            resolve_dns,
+            include_asn,
             interval_seconds,
             timeout_seconds,
         })
     }
+}
+
+fn validate_optional_count(value: Option<usize>) -> Result<Option<usize>, RestApiValidationError> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+
+    if raw == 0 {
+        return Err(RestApiValidationError::InvalidOption(
+            "count must be greater than or equal to 1".to_string(),
+        ));
+    }
+
+    Ok(Some(raw))
+}
+
+fn validate_optional_max_hops(value: Option<u16>) -> Result<Option<u8>, RestApiValidationError> {
+    let Some(raw) = value else {
+        return Ok(None);
+    };
+
+    if !(1..=255).contains(&raw) {
+        return Err(RestApiValidationError::InvalidOption(
+            "max_hops must be between 1 and 255".to_string(),
+        ));
+    }
+
+    Ok(Some(raw as u8))
 }
 
 fn validate_optional_positive(
@@ -413,6 +464,10 @@ mod tests {
             targets: vec![" Example.COM ".to_string(), "1.1.1.1".to_string()],
             protocol: ProbeProtocol::Tcp,
             port: Some(443),
+            count: None,
+            max_hops: None,
+            resolve_dns: None,
+            include_asn: None,
             interval_seconds: Some(1.0),
             timeout_seconds: Some(2.0),
         };
@@ -430,6 +485,10 @@ mod tests {
             targets: vec!["bad host".to_string()],
             protocol: ProbeProtocol::Icmp,
             port: None,
+            count: None,
+            max_hops: None,
+            resolve_dns: None,
+            include_asn: None,
             interval_seconds: None,
             timeout_seconds: None,
         };
@@ -497,6 +556,10 @@ mod tests {
             ],
             protocol: ProbeProtocol::Icmp,
             port: None,
+            count: None,
+            max_hops: None,
+            resolve_dns: None,
+            include_asn: None,
             interval_seconds: None,
             timeout_seconds: None,
         };

--- a/tests/api_contract_tests.rs
+++ b/tests/api_contract_tests.rs
@@ -232,3 +232,61 @@ fn openapi_contract_documents_cli_only_v1_out_of_scope() {
         );
     }
 }
+
+fn sorted(mut values: Vec<String>) -> Vec<String> {
+    values.sort();
+    values
+}
+
+fn create_probe_request_property_names(openapi: &Value, schema_name: &str) -> Vec<String> {
+    let openapi_map = as_mapping(openapi);
+    let components = as_mapping(map_get(openapi_map, "components"));
+    let schemas = as_mapping(map_get(components, "schemas"));
+    property_names(map_get(schemas, schema_name))
+}
+
+#[test]
+fn openapi_create_probe_request_fields_match_rust_dto_fields() {
+    use windows_mtr::service::api_models::{ApiProbeProtocol, CreateProbeRequestDto};
+
+    let dto = CreateProbeRequestDto {
+        targets: Vec::new(),
+        protocol: ApiProbeProtocol::Icmp,
+        port: None,
+        count: None,
+        max_hops: None,
+        resolve_dns: None,
+        include_asn: None,
+        interval_seconds: None,
+        timeout_seconds: None,
+    };
+
+    let dto_value = serde_json::to_value(dto).expect("dto should serialize");
+    let dto_fields = sorted(
+        dto_value
+            .as_object()
+            .expect("dto should serialize to object")
+            .keys()
+            .cloned()
+            .collect(),
+    );
+
+    let openapi = load_openapi();
+    let icmp_fields = sorted(create_probe_request_property_names(
+        &openapi,
+        "CreateProbeRequestIcmp",
+    ));
+    assert_eq!(
+        dto_fields, icmp_fields,
+        "CreateProbeRequestIcmp properties must match Rust DTO fields"
+    );
+
+    let tcp_udp_fields = sorted(create_probe_request_property_names(
+        &openapi,
+        "CreateProbeRequestTcpUdp",
+    ));
+    assert_eq!(
+        dto_fields, tcp_udp_fields,
+        "CreateProbeRequestTcpUdp properties must match Rust DTO fields"
+    );
+}

--- a/tests/api_contract_tests.rs
+++ b/tests/api_contract_tests.rs
@@ -272,14 +272,6 @@ fn openapi_create_probe_request_fields_match_rust_dto_fields() {
     );
 
     let openapi = load_openapi();
-    let icmp_fields = sorted(create_probe_request_property_names(
-        &openapi,
-        "CreateProbeRequestIcmp",
-    ));
-    assert_eq!(
-        dto_fields, icmp_fields,
-        "CreateProbeRequestIcmp properties must match Rust DTO fields"
-    );
 
     let tcp_udp_fields = sorted(create_probe_request_property_names(
         &openapi,
@@ -288,5 +280,16 @@ fn openapi_create_probe_request_fields_match_rust_dto_fields() {
     assert_eq!(
         dto_fields, tcp_udp_fields,
         "CreateProbeRequestTcpUdp properties must match Rust DTO fields"
+    );
+
+    let mut icmp_expected_fields = dto_fields.clone();
+    icmp_expected_fields.retain(|field| field != "port");
+    let icmp_fields = sorted(create_probe_request_property_names(
+        &openapi,
+        "CreateProbeRequestIcmp",
+    ));
+    assert_eq!(
+        icmp_expected_fields, icmp_fields,
+        "CreateProbeRequestIcmp properties must match Rust DTO fields except protocol-specific port"
     );
 }

--- a/tests/api_integration_tests.rs
+++ b/tests/api_integration_tests.rs
@@ -39,6 +39,10 @@ fn api_happy_path_accepts_valid_request_and_completes_before_timeout() {
         targets: vec![" Example.COM ".to_string(), "1.1.1.1".to_string()],
         protocol: ProbeProtocol::Tcp,
         port: Some(443),
+        count: Some(3),
+        max_hops: Some(64),
+        resolve_dns: Some(false),
+        include_asn: Some(true),
         interval_seconds: Some(0.5),
         timeout_seconds: Some(1.0),
     };
@@ -49,6 +53,10 @@ fn api_happy_path_accepts_valid_request_and_completes_before_timeout() {
 
     assert_eq!(normalized.targets, vec!["example.com", "1.1.1.1"]);
     assert_eq!(normalized.port, Some(443));
+    assert_eq!(normalized.count, Some(3));
+    assert_eq!(normalized.max_hops, Some(64));
+    assert!(!normalized.resolve_dns);
+    assert!(normalized.include_asn);
 
     let (_cancel_tx, cancel_rx) = mpsc::channel();
     let (complete_tx, complete_rx) = mpsc::channel();
@@ -68,6 +76,10 @@ fn api_validation_errors_reject_invalid_payload() {
         targets: vec!["bad host".to_string()],
         protocol: ProbeProtocol::Udp,
         port: None,
+        count: Some(3),
+        max_hops: Some(64),
+        resolve_dns: Some(false),
+        include_asn: Some(true),
         interval_seconds: Some(-0.1),
         timeout_seconds: Some(0.05),
     };

--- a/tests/rest_api_security_tests.rs
+++ b/tests/rest_api_security_tests.rs
@@ -44,6 +44,10 @@ fn request_validation_normalizes_and_deduplicates_targets() {
         ],
         protocol: ProbeProtocol::Tcp,
         port: Some(443),
+        count: None,
+        max_hops: None,
+        resolve_dns: None,
+        include_asn: None,
         interval_seconds: Some(0.5),
         timeout_seconds: Some(1.0),
     };
@@ -61,6 +65,10 @@ fn rejects_invalid_untrusted_inputs() {
         targets: vec!["bad host".to_string()],
         protocol: ProbeProtocol::Udp,
         port: Some(53),
+        count: None,
+        max_hops: None,
+        resolve_dns: None,
+        include_asn: None,
         interval_seconds: Some(-1.0),
         timeout_seconds: Some(0.5),
     };
@@ -125,6 +133,10 @@ fn rejects_too_many_targets_per_request() {
         ],
         protocol: ProbeProtocol::Icmp,
         port: None,
+        count: None,
+        max_hops: None,
+        resolve_dns: None,
+        include_asn: None,
         interval_seconds: None,
         timeout_seconds: None,
     };
@@ -132,5 +144,90 @@ fn rejects_too_many_targets_per_request() {
     assert!(matches!(
         request.normalize_and_validate(&RestApiConfig::default()),
         Err(RestApiValidationError::TooManyTargets { .. })
+    ));
+}
+
+#[test]
+fn normalizes_defaults_for_documented_optional_fields() {
+    let request = CreateProbeApiRequest {
+        targets: vec!["example.com".to_string()],
+        protocol: ProbeProtocol::Icmp,
+        port: None,
+        count: None,
+        max_hops: None,
+        resolve_dns: None,
+        include_asn: None,
+        interval_seconds: None,
+        timeout_seconds: None,
+    };
+
+    let normalized = request
+        .normalize_and_validate(&RestApiConfig::default())
+        .expect("request should validate");
+
+    assert_eq!(normalized.count, None);
+    assert_eq!(normalized.max_hops, None);
+    assert!(normalized.resolve_dns);
+    assert!(!normalized.include_asn);
+}
+
+#[test]
+fn accepts_documented_optional_fields_within_bounds() {
+    let request = CreateProbeApiRequest {
+        targets: vec!["example.com".to_string()],
+        protocol: ProbeProtocol::Tcp,
+        port: Some(443),
+        count: Some(5),
+        max_hops: Some(255),
+        resolve_dns: Some(false),
+        include_asn: Some(true),
+        interval_seconds: Some(0.25),
+        timeout_seconds: Some(1.0),
+    };
+
+    let normalized = request
+        .normalize_and_validate(&RestApiConfig::default())
+        .expect("request should validate");
+
+    assert_eq!(normalized.count, Some(5));
+    assert_eq!(normalized.max_hops, Some(255));
+    assert!(!normalized.resolve_dns);
+    assert!(normalized.include_asn);
+}
+
+#[test]
+fn rejects_out_of_bounds_count_and_max_hops() {
+    let config = RestApiConfig::default();
+
+    let zero_count = CreateProbeApiRequest {
+        targets: vec!["example.com".to_string()],
+        protocol: ProbeProtocol::Icmp,
+        port: None,
+        count: Some(0),
+        max_hops: None,
+        resolve_dns: None,
+        include_asn: None,
+        interval_seconds: None,
+        timeout_seconds: None,
+    };
+    assert!(matches!(
+        zero_count.normalize_and_validate(&config),
+        Err(RestApiValidationError::InvalidOption(_))
+    ));
+
+    let invalid_max_hops = CreateProbeApiRequest {
+        targets: vec!["example.com".to_string()],
+        protocol: ProbeProtocol::Icmp,
+        port: None,
+        count: None,
+        max_hops: Some(256),
+        resolve_dns: None,
+        include_asn: None,
+        interval_seconds: None,
+        timeout_seconds: None,
+    };
+    assert!(matches!(
+        invalid_max_hops.normalize_and_validate(&config),
+        Err(RestApiValidationError::InvalidOption(_))
     ));
 }


### PR DESCRIPTION
### Motivation
- The OpenAPI v1 contract documents optional create-probe fields (`count`, `max_hops`, `resolve_dns`, `include_asn`) that were not represented or validated in the Rust request model, leading to contract/runtime drift. 
- Align runtime request normalization/validation with the documented API to ensure predictable behavior and prevent subtle client/server mismatches.

### Description
- Extended request/normalized types: added `count`, `max_hops`, `resolve_dns`, and `include_asn` to `CreateProbeApiRequest` and `NormalizedCreateProbeRequest`, with `resolve_dns` and `include_asn` normalized to defaults (`true` and `false` respectively). 
- Added validation and normalization in `normalize_and_validate`: reject `count == 0`, enforce `max_hops` in `1..=255`, reject `port == 0`, and preserve existing interval/timeout checks. 
- Updated DTO layer in `CreateProbeRequestDto` and the `From<CreateProbeRequestDto>` mapping to carry the new fields, and derived `Serialize` on the DTO/protocol to enable contract parity testing. 
- Added tests: unit/integration tests that assert normalization defaults, in-range acceptance, and out-of-range rejection for the new fields, and a contract test that verifies OpenAPI `CreateProbeRequestIcmp`/`CreateProbeRequestTcpUdp` properties match the Rust DTO fields.

### Testing
- Ran formatting check with `cargo fmt --all -- --check`, which succeeded. 
- Attempted `cargo clippy --all-targets --all-features -- -D warnings` but it was blocked by the environment toolchain mismatch (`rustc 1.87.0` vs project/deps requiring `rustc 1.88.0`).
- Attempted `cargo test --all` but running tests was blocked by the same Rust toolchain mismatch; the newly added tests are included in the tree and will execute when run with a compatible Rust toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b607d94e9c83309cfa0e27549de076)