### PR TITLE
Harden REST API protocol/port validation

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -59,6 +59,20 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CreateProbeRequest'
+            examples:
+              icmp_valid:
+                summary: ICMP request (no port field)
+                value:
+                  targets: ["1.1.1.1", "example.com"]
+                  protocol: icmp
+                  count: 5
+              tcp_valid:
+                summary: TCP request (port required)
+                value:
+                  targets: ["1.1.1.1"]
+                  protocol: tcp
+                  port: 443
+                  timeout_seconds: 2
       responses:
         '202':
           description: Probe accepted
@@ -68,6 +82,12 @@ paths:
                 $ref: '#/components/schemas/CreateProbeResponse'
         '400':
           description: Invalid request payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Semantically invalid probe configuration (for example, tcp/udp without a required port)
           content:
             application/json:
               schema:
@@ -251,6 +271,7 @@ components:
           type: string
           enum: [icmp]
           default: icmp
+          description: ICMP probes do not accept a `port`; including `port` is rejected as an invalid request.
         count:
           type: integer
           minimum: 1
@@ -306,7 +327,7 @@ components:
           type: integer
           minimum: 1
           maximum: 65535
-          description: Required for tcp/udp probes (maps to `-P`, `--port`).
+          description: Required for tcp/udp probes (maps to `-P`, `--port`); not allowed for icmp probes.
         count:
           type: integer
           minimum: 1

--- a/src/service/rest_api.rs
+++ b/src/service/rest_api.rs
@@ -138,6 +138,12 @@ impl CreateProbeApiRequest {
             ));
         }
 
+        if matches!(self.protocol, ProbeProtocol::Icmp) && self.port.is_some() {
+            return Err(RestApiValidationError::InvalidPort(
+                "port is not allowed for icmp probes".to_string(),
+            ));
+        }
+
         if self.port == Some(0) {
             return Err(RestApiValidationError::InvalidPort(
                 "port must be between 1 and 65535".to_string(),
@@ -496,6 +502,26 @@ mod tests {
         assert!(matches!(
             request.normalize_and_validate(&RestApiConfig::default()),
             Err(RestApiValidationError::InvalidTarget(_))
+        ));
+    }
+
+    #[test]
+    fn normalize_rejects_port_for_icmp() {
+        let request = CreateProbeApiRequest {
+            targets: vec!["1.1.1.1".to_string()],
+            protocol: ProbeProtocol::Icmp,
+            port: Some(443),
+            count: None,
+            max_hops: None,
+            resolve_dns: None,
+            include_asn: None,
+            interval_seconds: None,
+            timeout_seconds: None,
+        };
+
+        assert!(matches!(
+            request.normalize_and_validate(&RestApiConfig::default()),
+            Err(RestApiValidationError::InvalidPort(_))
         ));
     }
 

--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -222,6 +222,11 @@ async fn run_with_timeout<T>(
 
 fn validation_error_response(error: RestApiValidationError) -> (StatusCode, String) {
     match error {
+        RestApiValidationError::InvalidPort(message)
+            if message == "port is required for tcp/udp probes" =>
+        {
+            (StatusCode::UNPROCESSABLE_ENTITY, error.to_string())
+        }
         RestApiValidationError::ConcurrencyLimitExceeded { .. }
         | RestApiValidationError::RateLimitExceeded { .. } => {
             (StatusCode::TOO_MANY_REQUESTS, error.to_string())

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -82,6 +82,50 @@ async fn create_probe_then_get_probe_by_id() {
 }
 
 #[tokio::test]
+async fn create_probe_rejects_icmp_with_port_as_bad_request() {
+    let (addr, shutdown) = spawn_server().await;
+    let client = reqwest::Client::new();
+
+    let create_res = client
+        .post(format!("http://{addr}/api/v1/probes"))
+        .json(&serde_json::json!({
+            "targets": ["1.1.1.1"],
+            "protocol": "icmp",
+            "port": 443
+        }))
+        .send()
+        .await
+        .expect("create probe request should succeed");
+
+    assert_eq!(create_res.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn create_probe_rejects_missing_tcp_port_as_unprocessable_entity() {
+    let (addr, shutdown) = spawn_server().await;
+    let client = reqwest::Client::new();
+
+    let create_res = client
+        .post(format!("http://{addr}/api/v1/probes"))
+        .json(&serde_json::json!({
+            "targets": ["1.1.1.1"],
+            "protocol": "tcp"
+        }))
+        .send()
+        .await
+        .expect("create probe request should succeed");
+
+    assert_eq!(
+        create_res.status(),
+        reqwest::StatusCode::UNPROCESSABLE_ENTITY
+    );
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
 async fn get_probe_returns_not_found_for_unknown_id() {
     let (addr, shutdown) = spawn_server().await;
     let client = reqwest::Client::new();


### PR DESCRIPTION
### Motivation
- Ensure the REST API enforces the intended protocol/port contract: `port` is required for TCP/UDP and must not be provided for ICMP probes.
- Make the API surface and OpenAPI contract explicit about the different failure semantics (malformed vs semantically invalid) and provide deterministic 4xx responses.

### Description
- Added an explicit validation in `CreateProbeApiRequest::normalize_and_validate` to return `RestApiValidationError::InvalidPort` when `protocol == Icmp` and `port.is_some()`, and preserved the existing TCP/UDP missing-port check (`src/service/rest_api.rs`).
- Updated server-side error mapping in `validation_error_response` so the existing "missing port for TCP/UDP" `InvalidPort` message maps to `422 Unprocessable Entity` while ICMP+port and other validation issues map to `400 Bad Request` (`src/service/rest_server.rs`).
- Added a unit test for ICMP+port rejection (`normalize_rejects_port_for_icmp`) and HTTP integration tests asserting ICMP+port => `400` and TCP without port => `422` (`tests/rest_server_http_tests.rs`).
- Updated the OpenAPI spec with examples and schema descriptions that explicitly state that `port` is disallowed for ICMP and added a `422` response for semantically invalid probe configurations (`docs/api/openapi.yaml`).

### Testing
- Ran formatting: `cargo fmt --all` succeeded after applying changes, and `cargo fmt --all -- --check` was exercised during validation steps.
- Attempted linting and tests: `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test --all` could not complete in this environment because the build host uses `rustc 1.87.0` while the project and dependencies require `rustc 1.88.0` (toolchain mismatch), so the new tests were added but not executed here.
- Changes were committed on the current branch with message `Harden REST API protocol/port validation` and include the code, tests, and OpenAPI updates described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61bc74474833089b4e931e8a44671)