### PR TITLE
Add strict OpenAPI YAML/schema validation and tighten API contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - 'docs/probe-parity.md'
       - 'docs/api/openapi.yaml'
       - 'scripts/check_openapi_compat.sh'
+      - 'scripts/validate_openapi_schema.py'
   pull_request:
     branches: [ master ]
     paths:
@@ -36,6 +37,7 @@ on:
       - 'docs/probe-parity.md'
       - 'docs/api/openapi.yaml'
       - 'scripts/check_openapi_compat.sh'
+      - 'scripts/validate_openapi_schema.py'
 permissions:
   contents: read
 
@@ -286,6 +288,14 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Install OpenAPI validation tooling
+        shell: bash
+        run: |
+          python3 -m pip install --disable-pip-version-check --no-input openapi-spec-validator ruamel.yaml
+
+      - name: Validate OpenAPI schema and duplicate YAML keys
+        run: python3 scripts/validate_openapi_schema.py docs/api/openapi.yaml
 
       - name: Run API contract tests
         run: cargo test --test api_contract_tests -- --nocapture

--- a/scripts/validate_openapi_schema.py
+++ b/scripts/validate_openapi_schema.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Validate OpenAPI YAML syntax, duplicate keys, and schema structure."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from openapi_spec_validator import OpenAPIV31SpecValidator
+from ruamel.yaml import YAML
+from ruamel.yaml.constructor import DuplicateKeyError
+
+
+def main() -> int:
+    path = Path(sys.argv[1] if len(sys.argv) > 1 else "docs/api/openapi.yaml")
+    if not path.exists():
+        print(f"OpenAPI spec not found: {path}", file=sys.stderr)
+        return 2
+
+    yaml = YAML(typ="safe")
+    yaml.allow_duplicate_keys = False
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            spec = yaml.load(handle)
+    except DuplicateKeyError as error:
+        print(f"Duplicate YAML key detected in {path}:\n{error}", file=sys.stderr)
+        return 1
+    except Exception as error:  # noqa: BLE001
+        print(f"Failed to parse {path}: {error}", file=sys.stderr)
+        return 1
+
+    errors = list(OpenAPIV31SpecValidator(spec).iter_errors())
+    if errors:
+        print(f"OpenAPI structural validation failed for {path}:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error.message}", file=sys.stderr)
+        return 1
+
+    print(f"OpenAPI schema validation passed: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api_contract_tests.rs
+++ b/tests/api_contract_tests.rs
@@ -145,10 +145,29 @@ fn openapi_contract_enforces_protocol_port_rules() {
         "CreateProbeRequest should have ICMP and TCP/UDP variants"
     );
 
-    let tcp_udp_required = required_property_names(map_get(schemas, "CreateProbeRequestTcpUdp"));
+    let icmp_required = required_property_names(map_get(schemas, "CreateProbeRequestIcmp"));
     assert!(
-        tcp_udp_required.iter().any(|field| field == "port"),
-        "CreateProbeRequestTcpUdp must require port"
+        icmp_required.iter().any(|field| field == "targets"),
+        "CreateProbeRequestIcmp must require targets"
+    );
+    assert!(
+        !icmp_required.iter().any(|field| field == "port"),
+        "CreateProbeRequestIcmp must not require port"
+    );
+
+    let tcp_udp_required = required_property_names(map_get(schemas, "CreateProbeRequestTcpUdp"));
+    for required in ["targets", "protocol", "port"] {
+        assert!(
+            tcp_udp_required.iter().any(|field| field == required),
+            "CreateProbeRequestTcpUdp must require {required}"
+        );
+    }
+
+    assert!(
+        !tcp_udp_required
+            .iter()
+            .any(|field| field == "timeout_seconds"),
+        "CreateProbeRequestTcpUdp must not require optional tuning fields"
     );
 }
 


### PR DESCRIPTION
### Motivation
- Prevent silent regressions from duplicate YAML keys in the OpenAPI spec and catch malformed OpenAPI structure early in CI. 
- Make the API contract tests assert protocol-specific required fields so schema drift (e.g. accidental required/duplicate properties) is detected earlier.

### Description
- Added `scripts/validate_openapi_schema.py` which rejects duplicate YAML keys using `ruamel.yaml` and validates OpenAPI 3.1 structure with `openapi-spec-validator`.
- Updated the CI job (`.github/workflows/ci.yml`) to install the Python OpenAPI tooling and run the new validator before running API contract tests, and included the validator script in the push/PR path filters.
- Expanded `tests/api_contract_tests.rs` to assert explicit requirements for both variants: ICMP must require `targets` and must not require `port`, while TCP/UDP must require `targets`, `protocol`, and `port` and must not require optional tuning fields.
- Ensured the OpenAPI document no longer contains the duplicated `interval_seconds` entry under the CreateProbeRequest schema area and relied on the new validator to prevent regressions.

### Testing
- Ran `python3 scripts/validate_openapi_schema.py docs/api/openapi.yaml`; result: passed.
- Ran formatting checks: `cargo fmt --all -- --check`; result: passed after formatting.
- Ran lints: `cargo +1.88.0 clippy --all-targets --all-features -- -D warnings`; result: passed (noting CI/tooling installs the MSRV toolchain where needed).
- Ran contract tests: `cargo +1.88.0 test --test api_contract_tests -- --nocapture`; result: all assertions passed (6 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61bcc80048330b75bb39344b89c5c)