### PR TITLE
Add REST probe request guards for payload size and fixed-window rate limiting

### DIFF
--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
-use axum::extract::{ConnectInfo, Path, State};
+use axum::body::{Body, to_bytes};
+use axum::extract::{ConnectInfo, Path, Request, State};
 use axum::http::{HeaderMap, StatusCode};
+use axum::middleware::{Next, from_fn_with_state};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use tokio::net::TcpListener;
@@ -16,8 +18,9 @@ use crate::service::api_models::{
     CreateProbeRequestDto, CreateProbeResponseDto, HealthResponseDto, ProbeResultResponseDto,
 };
 use crate::service::rest_api::{
-    AuthStrategy, CreateProbeApiRequest, NormalizedCreateProbeRequest, ProbeConcurrencyGate,
-    ProbeProtocol, RestApiConfig, RestApiValidationError,
+    AuthStrategy, CreateProbeApiRequest, FixedWindowRateLimiter, NormalizedCreateProbeRequest,
+    ProbeConcurrencyGate, ProbeProtocol, RestApiConfig, RestApiValidationError,
+    validate_payload_size,
 };
 
 const API_KEY_HEADER: &str = "X-API-Key";
@@ -120,6 +123,7 @@ impl ProbeStore {
 pub struct RestServerState {
     pub config: RestApiConfig,
     pub concurrency_gate: Arc<ProbeConcurrencyGate>,
+    probe_rate_limiter: Arc<Mutex<FixedWindowRateLimiter>>,
     store: Arc<Mutex<ProbeStore>>,
     next_id: Arc<AtomicU64>,
 }
@@ -127,10 +131,16 @@ pub struct RestServerState {
 impl RestServerState {
     pub fn new(config: RestApiConfig) -> Result<Self, RestApiValidationError> {
         let gate = Arc::new(ProbeConcurrencyGate::new(config.max_concurrent_probes)?);
+        let limiter = Arc::new(Mutex::new(FixedWindowRateLimiter::new(
+            config.max_concurrent_probes,
+            config.request_timeout,
+            Instant::now(),
+        )?));
 
         Ok(Self {
             config,
             concurrency_gate: gate,
+            probe_rate_limiter: limiter,
             store: Arc::new(Mutex::new(ProbeStore {
                 jobs: HashMap::new(),
             })),
@@ -145,11 +155,49 @@ impl RestServerState {
 }
 
 pub fn build_router(state: RestServerState) -> Router {
+    let probe_guard_state = state.clone();
+
     Router::new()
         .route("/api/v1/health", get(get_health))
-        .route("/api/v1/probes", post(create_probe))
+        .route(
+            "/api/v1/probes",
+            post(create_probe).route_layer(from_fn_with_state(
+                probe_guard_state,
+                enforce_probe_request_guards,
+            )),
+        )
         .route("/api/v1/probes/{id}", get(get_probe))
         .with_state(state)
+}
+
+async fn enforce_probe_request_guards(
+    State(state): State<RestServerState>,
+    request: Request,
+    next: Next,
+) -> Result<axum::response::Response, (StatusCode, Json<ErrorEnvelope>)> {
+    {
+        let mut limiter = state
+            .probe_rate_limiter
+            .lock()
+            .map_err(|_| internal_error_response("failed to lock probe rate limiter"))?;
+        limiter
+            .allow(Instant::now())
+            .map_err(validation_error_response)?;
+    }
+
+    let (parts, body) = request.into_parts();
+    let payload = to_bytes(body, state.config.max_payload_bytes + 1)
+        .await
+        .map_err(|_| {
+            validation_error_response(RestApiValidationError::OversizedPayload(
+                "request body exceeds configured payload limit".to_string(),
+            ))
+        })?;
+
+    validate_payload_size(payload.len(), &state.config).map_err(validation_error_response)?;
+
+    let request = Request::from_parts(parts, Body::from(payload));
+    Ok(next.run(request).await)
 }
 
 pub async fn run_rest_api_server(config: RestApiConfig) -> anyhow::Result<()> {

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -235,6 +235,80 @@ async fn create_probe_rejects_missing_tcp_port_as_unprocessable_entity() {
 }
 
 #[tokio::test]
+async fn create_probe_rejects_oversized_payload_with_413() {
+    let config = RestApiConfig {
+        max_payload_bytes: 32,
+        ..RestApiConfig::default()
+    };
+    let (addr, shutdown) = spawn_server_with_config(config).await;
+    let client = build_http_client();
+
+    let oversized_targets = ["a".repeat(64)];
+    let create_res = client
+        .post(format!("http://{addr}/api/v1/probes"))
+        .json(&serde_json::json!({
+            "targets": oversized_targets,
+            "protocol": "icmp"
+        }))
+        .send()
+        .await
+        .expect("create probe request should succeed");
+
+    assert_eq!(create_res.status(), reqwest::StatusCode::PAYLOAD_TOO_LARGE);
+
+    let body: serde_json::Value = create_res.json().await.expect("json body expected");
+    assert_eq!(body["error"]["code"], "payload_too_large");
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn create_probe_rejects_burst_traffic_with_429() {
+    let config = RestApiConfig {
+        request_timeout: Duration::from_secs(1),
+        max_concurrent_probes: 2,
+        ..RestApiConfig::default()
+    };
+    let (addr, shutdown) = spawn_server_with_config(config).await;
+    let client = build_http_client();
+
+    let url = format!("http://{addr}/api/v1/probes");
+    let payload = serde_json::json!({
+        "targets": ["1.1.1.1"],
+        "protocol": "icmp"
+    });
+
+    let first = client
+        .post(&url)
+        .json(&payload)
+        .send()
+        .await
+        .expect("first create probe request should succeed");
+    assert_eq!(first.status(), reqwest::StatusCode::ACCEPTED);
+
+    let second = client
+        .post(&url)
+        .json(&payload)
+        .send()
+        .await
+        .expect("second create probe request should succeed");
+    assert_eq!(second.status(), reqwest::StatusCode::ACCEPTED);
+
+    let third = client
+        .post(&url)
+        .json(&payload)
+        .send()
+        .await
+        .expect("third create probe request should succeed");
+    assert_eq!(third.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+
+    let body: serde_json::Value = third.json().await.expect("json body expected");
+    assert_eq!(body["error"]["code"], "rate_limited");
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
 async fn api_key_auth_rejects_missing_or_invalid_key_and_accepts_valid_key() {
     let config = RestApiConfig {
         auth_strategy: AuthStrategy::ApiKey,


### PR DESCRIPTION
### Motivation
- Enforce documented abuse-prevention controls (payload-size and rate-limiting) earlier in the request pipeline so invalid/abusive probe requests are rejected before probe creation logic runs.
- Reuse existing validation primitives from `src/service/rest_api.rs` to keep behavior and defaults aligned with README/USAGE (e.g. `max_payload_bytes = 16 KiB`).

### Description
- Added a shared `FixedWindowRateLimiter` to `RestServerState` and initialized it from existing config values (`max_concurrent_probes` and `request_timeout`).
- Introduced a middleware `enforce_probe_request_guards` applied to `POST /api/v1/probes` that (1) acquires the fixed-window allowance and maps rate failures to the existing validation path, and (2) reads the request body with a hard cap and invokes `validate_payload_size` to map oversized bodies to the existing `413` handling.
- Kept error-to-status mappings consistent by funneling guard errors through `validation_error_response` so rate/concurrency failures return `429` (`rate_limited`) and oversized payloads return `413` (`payload_too_large`).
- Added integration tests in `tests/rest_server_http_tests.rs` that exercise oversized payload rejection (`413`) and burst traffic rejection (`429`).

### Testing
- Ran formatting: `cargo fmt --all` and `cargo fmt --all -- --check` succeeded.
- Attempted linting: `cargo clippy --all-targets --all-features -- -D warnings` failed due to the environment using `rustc 1.87.0` while this repository and some dependencies require `rustc 1.88.0+`.
- Attempted test run: `cargo test --all` could not run in this environment for the same `rustc` toolchain mismatch, but the new integration tests were added under `tests/rest_server_http_tests.rs` for `413`/`429` scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7bc680fec833092222da783ce41cf)