### PR TITLE
Align REST handlers with structured API response envelopes

### DIFF
--- a/src/service/api_models.rs
+++ b/src/service/api_models.rs
@@ -52,6 +52,19 @@ impl From<CreateProbeRequestDto> for CreateProbeApiRequest {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct HealthResponseDto {
+    pub meta: ApiResponseMetaDto,
+    pub data: HealthDataDto,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiResponseMetaDto {
+    pub schema_version: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthDataDto {
     pub status: &'static str,
     pub service: &'static str,
     pub version: &'static str,
@@ -59,12 +72,24 @@ pub struct HealthResponseDto {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CreateProbeResponseDto {
+    pub meta: ApiResponseMetaDto,
+    pub data: CreateProbeDataDto,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateProbeDataDto {
     pub id: String,
     pub status: ApiProbeStatusDto,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ProbeResultResponseDto {
+    pub meta: ApiResponseMetaDto,
+    pub data: ProbeResultDataDto,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProbeResultDataDto {
     pub id: String,
     pub status: ApiProbeStatusDto,
     pub result: Option<ProbeExecutionResultDto>,
@@ -111,10 +136,16 @@ impl From<ProbeJobStatus> for ApiProbeStatusDto {
 impl From<&ProbeJob> for ProbeResultResponseDto {
     fn from(value: &ProbeJob) -> Self {
         Self {
-            id: value.id.clone(),
-            status: value.status.into(),
-            result: value.result.clone().map(Into::into),
-            error: value.error.clone(),
+            meta: ApiResponseMetaDto {
+                schema_version: "v1",
+                request_id: None,
+            },
+            data: ProbeResultDataDto {
+                id: value.id.clone(),
+                status: value.status.into(),
+                result: value.result.clone().map(Into::into),
+                error: value.error.clone(),
+            },
         }
     }
 }

--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -14,8 +14,10 @@ use tokio::net::TcpListener;
 use tokio::signal;
 use tokio::time::timeout;
 
+use crate::api_error::ApiError;
 use crate::service::api_models::{
-    CreateProbeRequestDto, CreateProbeResponseDto, HealthResponseDto, ProbeResultResponseDto,
+    ApiResponseMetaDto, CreateProbeDataDto, CreateProbeRequestDto, CreateProbeResponseDto,
+    HealthDataDto, HealthResponseDto, ProbeResultResponseDto,
 };
 use crate::service::rest_api::{
     AuthStrategy, CreateProbeApiRequest, FixedWindowRateLimiter, NormalizedCreateProbeRequest,
@@ -25,16 +27,7 @@ use crate::service::rest_api::{
 
 const API_KEY_HEADER: &str = "X-API-Key";
 
-#[derive(Debug, Clone, serde::Serialize)]
-struct ErrorEnvelope {
-    error: AuthErrorBody,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-struct AuthErrorBody {
-    code: &'static str,
-    message: String,
-}
+type ApiResult<T> = Result<T, ApiError>;
 
 #[derive(Debug, Clone)]
 enum RequestAuthError {
@@ -44,39 +37,27 @@ enum RequestAuthError {
 }
 
 impl RequestAuthError {
-    fn into_response(self) -> (StatusCode, Json<ErrorEnvelope>) {
+    fn into_api_error(self) -> ApiError {
         match self {
-            Self::MissingApiKeyHeader => (
-                StatusCode::UNAUTHORIZED,
-                Json(ErrorEnvelope {
-                    error: AuthErrorBody {
-                        code: "missing_api_key",
-                        message: format!(
-                            "missing required authentication header: {API_KEY_HEADER}"
-                        ),
-                    },
-                }),
-            ),
-            Self::InvalidApiKey => (
-                StatusCode::FORBIDDEN,
-                Json(ErrorEnvelope {
-                    error: AuthErrorBody {
-                        code: "invalid_api_key",
-                        message: "provided API key is invalid".to_string(),
-                    },
-                }),
-            ),
-            Self::MissingMtlsIdentity => (
-                StatusCode::UNAUTHORIZED,
-                Json(ErrorEnvelope {
-                    error: AuthErrorBody {
-                        code: "missing_mtls_identity",
-                        message:
-                            "mTLS is configured but request identity was not provided by upstream"
-                                .to_string(),
-                    },
-                }),
-            ),
+            Self::MissingApiKeyHeader => ApiError {
+                status: StatusCode::UNAUTHORIZED,
+                code: "missing_api_key",
+                title: "Authentication required",
+                detail: format!("missing required authentication header: {API_KEY_HEADER}"),
+            },
+            Self::InvalidApiKey => ApiError {
+                status: StatusCode::FORBIDDEN,
+                code: "invalid_api_key",
+                title: "Forbidden",
+                detail: "provided API key is invalid".to_string(),
+            },
+            Self::MissingMtlsIdentity => ApiError {
+                status: StatusCode::UNAUTHORIZED,
+                code: "missing_mtls_identity",
+                title: "Authentication required",
+                detail: "mTLS is configured but request identity was not provided by upstream"
+                    .to_string(),
+            },
         }
     }
 }
@@ -174,7 +155,7 @@ async fn enforce_probe_request_guards(
     State(state): State<RestServerState>,
     request: Request,
     next: Next,
-) -> Result<axum::response::Response, (StatusCode, Json<ErrorEnvelope>)> {
+) -> ApiResult<axum::response::Response> {
     {
         let mut limiter = state
             .probe_rate_limiter
@@ -229,12 +210,18 @@ async fn get_health(
     ConnectInfo(remote_addr): ConnectInfo<std::net::SocketAddr>,
     State(state): State<RestServerState>,
     headers: HeaderMap,
-) -> Result<Json<HealthResponseDto>, (StatusCode, Json<ErrorEnvelope>)> {
+) -> ApiResult<Json<HealthResponseDto>> {
     enforce_request_auth(&state.config, remote_addr, &headers)?;
     Ok(Json(HealthResponseDto {
-        status: "ok",
-        service: "windows-mtr",
-        version: env!("CARGO_PKG_VERSION"),
+        meta: ApiResponseMetaDto {
+            schema_version: "v1",
+            request_id: None,
+        },
+        data: HealthDataDto {
+            status: "ok",
+            service: "windows-mtr",
+            version: env!("CARGO_PKG_VERSION"),
+        },
     }))
 }
 
@@ -243,7 +230,7 @@ async fn create_probe(
     State(state): State<RestServerState>,
     headers: HeaderMap,
     Json(payload): Json<CreateProbeRequestDto>,
-) -> Result<(StatusCode, Json<CreateProbeResponseDto>), (StatusCode, Json<ErrorEnvelope>)> {
+) -> ApiResult<(StatusCode, Json<CreateProbeResponseDto>)> {
     enforce_request_auth(&state.config, remote_addr, &headers)?;
 
     run_with_timeout(state.config.request_timeout, async move {
@@ -277,8 +264,14 @@ async fn create_probe(
         Ok((
             StatusCode::ACCEPTED,
             Json(CreateProbeResponseDto {
-                id,
-                status: ProbeJobStatus::Queued.into(),
+                meta: ApiResponseMetaDto {
+                    schema_version: "v1",
+                    request_id: None,
+                },
+                data: CreateProbeDataDto {
+                    id,
+                    status: ProbeJobStatus::Queued.into(),
+                },
             }),
         ))
     })
@@ -386,15 +379,16 @@ async fn get_probe(
     State(state): State<RestServerState>,
     headers: HeaderMap,
     Path(id): Path<String>,
-) -> Result<Json<ProbeResultResponseDto>, (StatusCode, Json<ErrorEnvelope>)> {
+) -> ApiResult<Json<ProbeResultResponseDto>> {
     enforce_request_auth(&state.config, remote_addr, &headers)?;
 
     run_with_timeout(state.config.request_timeout, async move {
-        if id.trim().is_empty() {
+        if id.trim().is_empty() || id.chars().any(char::is_whitespace) {
             return Err(error_response(
                 StatusCode::BAD_REQUEST,
                 "invalid_probe_id",
-                "probe id must not be empty".to_string(),
+                "Invalid probe id",
+                "probe id must not be empty or contain whitespace".to_string(),
             ));
         }
 
@@ -406,6 +400,7 @@ async fn get_probe(
             error_response(
                 StatusCode::NOT_FOUND,
                 "probe_not_found",
+                "Probe not found",
                 format!("probe not found: {id}"),
             )
         })?;
@@ -417,19 +412,20 @@ async fn get_probe(
 
 async fn run_with_timeout<T>(
     duration: std::time::Duration,
-    future: impl std::future::Future<Output = Result<T, (StatusCode, Json<ErrorEnvelope>)>>,
-) -> Result<T, (StatusCode, Json<ErrorEnvelope>)> {
+    future: impl std::future::Future<Output = ApiResult<T>>,
+) -> ApiResult<T> {
     match timeout(duration, future).await {
         Ok(result) => result,
         Err(_) => Err(error_response(
             StatusCode::REQUEST_TIMEOUT,
             "request_timeout",
+            "Request timed out",
             format!("request processing exceeded timeout of {duration:?}"),
         )),
     }
 }
 
-fn validation_error_response(error: RestApiValidationError) -> (StatusCode, Json<ErrorEnvelope>) {
+fn validation_error_response(error: RestApiValidationError) -> ApiError {
     match error {
         RestApiValidationError::InvalidPort(ref message)
             if message == "port is required for tcp/udp probes" =>
@@ -437,6 +433,7 @@ fn validation_error_response(error: RestApiValidationError) -> (StatusCode, Json
             error_response(
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "invalid_request",
+                "Invalid request",
                 error.to_string(),
             )
         }
@@ -444,25 +441,29 @@ fn validation_error_response(error: RestApiValidationError) -> (StatusCode, Json
         | RestApiValidationError::RateLimitExceeded { .. } => error_response(
             StatusCode::TOO_MANY_REQUESTS,
             "rate_limited",
+            "Rate limited",
             error.to_string(),
         ),
         RestApiValidationError::OversizedPayload(_) => error_response(
             StatusCode::PAYLOAD_TOO_LARGE,
             "payload_too_large",
+            "Payload too large",
             error.to_string(),
         ),
         _ => error_response(
             StatusCode::BAD_REQUEST,
             "invalid_request",
+            "Invalid request",
             error.to_string(),
         ),
     }
 }
 
-fn internal_error_response(message: &str) -> (StatusCode, Json<ErrorEnvelope>) {
+fn internal_error_response(message: &str) -> ApiError {
     error_response(
         StatusCode::INTERNAL_SERVER_ERROR,
         "internal_error",
+        "Internal server error",
         message.to_string(),
     )
 }
@@ -470,33 +471,34 @@ fn internal_error_response(message: &str) -> (StatusCode, Json<ErrorEnvelope>) {
 fn error_response(
     status: StatusCode,
     code: &'static str,
-    message: String,
-) -> (StatusCode, Json<ErrorEnvelope>) {
-    (
+    title: &'static str,
+    detail: String,
+) -> ApiError {
+    ApiError {
         status,
-        Json(ErrorEnvelope {
-            error: AuthErrorBody { code, message },
-        }),
-    )
+        code,
+        title,
+        detail,
+    }
 }
 
 fn enforce_request_auth(
     config: &RestApiConfig,
     remote_addr: std::net::SocketAddr,
     headers: &HeaderMap,
-) -> Result<(), (StatusCode, Json<ErrorEnvelope>)> {
+) -> ApiResult<()> {
     let request_is_loopback = remote_addr.ip().is_loopback();
 
     match config.auth_strategy {
         AuthStrategy::NoneLocalOnly if request_is_loopback => Ok(()),
-        AuthStrategy::NoneLocalOnly => Err(RequestAuthError::MissingApiKeyHeader.into_response()),
+        AuthStrategy::NoneLocalOnly => Err(RequestAuthError::MissingApiKeyHeader.into_api_error()),
         AuthStrategy::ApiKey => {
             let provided = headers
                 .get(API_KEY_HEADER)
                 .and_then(|value| value.to_str().ok())
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
-                .ok_or_else(|| RequestAuthError::MissingApiKeyHeader.into_response())?;
+                .ok_or_else(|| RequestAuthError::MissingApiKeyHeader.into_api_error())?;
 
             let expected = config
                 .api_key
@@ -506,6 +508,7 @@ fn enforce_request_auth(
                     error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "auth_configuration_error",
+                        "Internal server error",
                         "auth_strategy=api-key requires configured api_key".to_string(),
                     )
                 })?;
@@ -513,14 +516,14 @@ fn enforce_request_auth(
             if provided == expected {
                 Ok(())
             } else {
-                Err(RequestAuthError::InvalidApiKey.into_response())
+                Err(RequestAuthError::InvalidApiKey.into_api_error())
             }
         }
         AuthStrategy::Mtls => headers
             .get("X-Client-Cert")
             .or_else(|| headers.get("X-SSL-Client-Verify"))
             .map(|_| ())
-            .ok_or_else(|| RequestAuthError::MissingMtlsIdentity.into_response()),
+            .ok_or_else(|| RequestAuthError::MissingMtlsIdentity.into_api_error()),
     }
 }
 

--- a/tests/api_contract_tests.rs
+++ b/tests/api_contract_tests.rs
@@ -252,6 +252,57 @@ fn openapi_contract_documents_cli_only_v1_out_of_scope() {
     }
 }
 
+#[test]
+fn openapi_contract_response_schemas_require_meta_and_data_envelope() {
+    let openapi = load_openapi();
+    let openapi_map = as_mapping(&openapi);
+    let components = as_mapping(map_get(openapi_map, "components"));
+    let schemas = as_mapping(map_get(components, "schemas"));
+
+    for schema_name in ["HealthResponse", "CreateProbeResponse", "GetProbeResponse"] {
+        let required = required_property_names(map_get(schemas, schema_name));
+        assert!(
+            required.iter().any(|field| field == "meta"),
+            "{schema_name} must require meta"
+        );
+        assert!(
+            required.iter().any(|field| field == "data"),
+            "{schema_name} must require data"
+        );
+    }
+}
+
+#[test]
+fn openapi_contract_documents_runtime_emitted_probe_response_codes() {
+    let openapi = load_openapi();
+    let openapi_map = as_mapping(&openapi);
+    let paths = as_mapping(map_get(openapi_map, "paths"));
+
+    let post_probe = as_mapping(map_get(
+        as_mapping(map_get(paths, "/api/v1/probes")),
+        "post",
+    ));
+    let post_responses = as_mapping(map_get(post_probe, "responses"));
+    for status in ["202", "400", "413", "422", "429"] {
+        assert!(
+            map_get_optional(post_responses, status).is_some(),
+            "POST /api/v1/probes must document {status}"
+        );
+    }
+
+    let get_probe = as_mapping(map_get(
+        as_mapping(map_get(paths, "/api/v1/probes/{id}")),
+        "get",
+    ));
+    let get_responses = as_mapping(map_get(get_probe, "responses"));
+    for status in ["200", "400", "404"] {
+        assert!(
+            map_get_optional(get_responses, status).is_some(),
+            "GET /api/v1/probes/{{id}} must document {status}"
+        );
+    }
+}
+
 fn sorted(mut values: Vec<String>) -> Vec<String> {
     values.sort();
     values

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -43,6 +43,20 @@ async fn spawn_server() -> (SocketAddr, oneshot::Sender<()>) {
     spawn_server_with_config(RestApiConfig::default()).await
 }
 
+fn assert_meta(body: &serde_json::Value) {
+    assert_eq!(body["meta"]["schema_version"], "v1");
+    assert!(body["meta"]["request_id"].is_null());
+}
+
+fn assert_error_shape(body: &serde_json::Value, status: u16, code: &str) {
+    assert_meta(body);
+    assert_eq!(body["error"]["status"], status);
+    assert_eq!(body["error"]["code"], code);
+    assert!(body["error"]["type"].is_string());
+    assert!(body["error"]["title"].is_string());
+    assert!(body["error"]["detail"].is_string());
+}
+
 async fn create_probe(
     client: &reqwest::Client,
     addr: SocketAddr,
@@ -82,7 +96,7 @@ async fn wait_for_probe_status(
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
         let probe = fetch_probe(client, addr, id).await;
-        if probe["status"] == expected {
+        if probe["data"]["status"] == expected {
             return probe;
         }
 
@@ -105,7 +119,7 @@ async fn wait_for_terminal_status_with_running_seen(
 
     loop {
         let probe = fetch_probe(client, addr, id).await;
-        match probe["status"].as_str() {
+        match probe["data"]["status"].as_str() {
             Some("running") => saw_running = true,
             Some(status) if status == expected_terminal => {
                 assert!(
@@ -138,7 +152,9 @@ async fn health_endpoint_returns_ok() {
 
     assert_eq!(res.status(), reqwest::StatusCode::OK);
     let body: serde_json::Value = res.json().await.expect("json body expected");
-    assert_eq!(body["status"], "ok");
+    assert_meta(&body);
+    assert_eq!(body["data"]["status"], "ok");
+    assert_eq!(body["data"]["service"], "windows-mtr");
 
     let _ = shutdown.send(());
 }
@@ -149,23 +165,28 @@ async fn create_probe_transitions_through_queued_running_and_completed() {
     let client = build_http_client();
 
     let created = create_probe(&client, addr, "1.1.1.1").await;
-    let id = created["id"].as_str().expect("id should be a string");
-    assert_eq!(created["status"], "queued");
+    assert_meta(&created);
+    let id = created["data"]["id"]
+        .as_str()
+        .expect("id should be a string");
+    assert_eq!(created["data"]["status"], "queued");
 
     let queued_or_running = fetch_probe(&client, addr, id).await;
     assert!(
-        queued_or_running["status"] == "queued" || queued_or_running["status"] == "running",
+        queued_or_running["data"]["status"] == "queued"
+            || queued_or_running["data"]["status"] == "running",
         "expected queued or running status, got {queued_or_running}"
     );
 
     let completed =
         wait_for_terminal_status_with_running_seen(&client, addr, id, "completed").await;
 
-    assert_eq!(completed["id"], id);
-    assert_eq!(completed["result"]["targets"][0], "1.1.1.1");
-    assert_eq!(completed["result"]["protocol"], "icmp");
-    assert_eq!(completed["result"]["completed"], true);
-    assert_eq!(completed["error"], serde_json::Value::Null);
+    assert_meta(&completed);
+    assert_eq!(completed["data"]["id"], id);
+    assert_eq!(completed["data"]["result"]["targets"][0], "1.1.1.1");
+    assert_eq!(completed["data"]["result"]["protocol"], "icmp");
+    assert_eq!(completed["data"]["result"]["completed"], true);
+    assert_eq!(completed["data"]["error"], serde_json::Value::Null);
 
     let _ = shutdown.send(());
 }
@@ -176,12 +197,16 @@ async fn create_probe_failed_transition_persists_error_details() {
     let client = build_http_client();
 
     let created = create_probe(&client, addr, "simulate-failure").await;
-    let id = created["id"].as_str().expect("id should be a string");
+    assert_meta(&created);
+    let id = created["data"]["id"]
+        .as_str()
+        .expect("id should be a string");
 
     let failed = wait_for_probe_status(&client, addr, id, "failed").await;
-    assert_eq!(failed["result"], serde_json::Value::Null);
+    assert_meta(&failed);
+    assert_eq!(failed["data"]["result"], serde_json::Value::Null);
     assert!(
-        failed["error"]
+        failed["data"]["error"]
             .as_str()
             .expect("error text should exist")
             .contains("simulate-failure")
@@ -207,6 +232,8 @@ async fn create_probe_rejects_icmp_with_port_as_bad_request() {
         .expect("create probe request should succeed");
 
     assert_eq!(create_res.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = create_res.json().await.expect("json body expected");
+    assert_error_shape(&body, 400, "invalid_request");
 
     let _ = shutdown.send(());
 }
@@ -230,6 +257,8 @@ async fn create_probe_rejects_missing_tcp_port_as_unprocessable_entity() {
         create_res.status(),
         reqwest::StatusCode::UNPROCESSABLE_ENTITY
     );
+    let body: serde_json::Value = create_res.json().await.expect("json body expected");
+    assert_error_shape(&body, 422, "invalid_request");
 
     let _ = shutdown.send(());
 }
@@ -257,7 +286,7 @@ async fn create_probe_rejects_oversized_payload_with_413() {
     assert_eq!(create_res.status(), reqwest::StatusCode::PAYLOAD_TOO_LARGE);
 
     let body: serde_json::Value = create_res.json().await.expect("json body expected");
-    assert_eq!(body["error"]["code"], "payload_too_large");
+    assert_error_shape(&body, 413, "payload_too_large");
 
     let _ = shutdown.send(());
 }
@@ -303,7 +332,7 @@ async fn create_probe_rejects_burst_traffic_with_429() {
     assert_eq!(third.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
 
     let body: serde_json::Value = third.json().await.expect("json body expected");
-    assert_eq!(body["error"]["code"], "rate_limited");
+    assert_error_shape(&body, 429, "rate_limited");
 
     let _ = shutdown.send(());
 }
@@ -326,7 +355,7 @@ async fn api_key_auth_rejects_missing_or_invalid_key_and_accepts_valid_key() {
     assert_eq!(missing.status(), reqwest::StatusCode::UNAUTHORIZED);
 
     let missing_body: serde_json::Value = missing.json().await.expect("json body expected");
-    assert_eq!(missing_body["error"]["code"], "missing_api_key");
+    assert_error_shape(&missing_body, 401, "missing_api_key");
 
     let invalid = client
         .get(format!("http://{addr}/api/v1/health"))
@@ -337,7 +366,7 @@ async fn api_key_auth_rejects_missing_or_invalid_key_and_accepts_valid_key() {
     assert_eq!(invalid.status(), reqwest::StatusCode::FORBIDDEN);
 
     let invalid_body: serde_json::Value = invalid.json().await.expect("json body expected");
-    assert_eq!(invalid_body["error"]["code"], "invalid_api_key");
+    assert_error_shape(&invalid_body, 403, "invalid_api_key");
 
     let ok = client
         .get(format!("http://{addr}/api/v1/health"))
@@ -367,7 +396,7 @@ async fn mtls_auth_requires_upstream_client_identity_header() {
     assert_eq!(unauthorized.status(), reqwest::StatusCode::UNAUTHORIZED);
 
     let body: serde_json::Value = unauthorized.json().await.expect("json body expected");
-    assert_eq!(body["error"]["code"], "missing_mtls_identity");
+    assert_error_shape(&body, 401, "missing_mtls_identity");
 
     let authorized = client
         .get(format!("http://{addr}/api/v1/health"))
@@ -376,6 +405,24 @@ async fn mtls_auth_requires_upstream_client_identity_header() {
         .await
         .expect("request should succeed");
     assert_eq!(authorized.status(), reqwest::StatusCode::OK);
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn get_probe_rejects_whitespace_id_as_bad_request() {
+    let (addr, shutdown) = spawn_server().await;
+    let client = build_http_client();
+
+    let res = client
+        .get(format!("http://{addr}/api/v1/probes/%20"))
+        .send()
+        .await
+        .expect("get request should succeed");
+
+    assert_eq!(res.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = res.json().await.expect("json body expected");
+    assert_error_shape(&body, 400, "invalid_probe_id");
 
     let _ = shutdown.send(());
 }
@@ -392,6 +439,8 @@ async fn get_probe_returns_not_found_for_unknown_id() {
         .expect("get request should succeed");
 
     assert_eq!(res.status(), reqwest::StatusCode::NOT_FOUND);
+    let body: serde_json::Value = res.json().await.expect("json body expected");
+    assert_error_shape(&body, 404, "probe_not_found");
 
     let _ = shutdown.send(());
 }


### PR DESCRIPTION
### Motivation
- Ensure the runtime REST handlers emit the same structured envelope (`meta` + `error` / `meta` + `data`) already defined in `src/api_error.rs` and documented in `docs/api/openapi.yaml`.
- Remove ad-hoc `(StatusCode, String)` and bespoke auth error envelopes to provide consistent machine-readable problem details for clients and OpenAPI consumers.
- Exercise documented error response codes with reachable code paths so contract tests validate real behavior.

### Description
- Replaced ad-hoc auth/error tuple responses and custom `ErrorEnvelope` with the `ApiError` model and introduced `ApiResult<T>` in `src/service/rest_server.rs` so handlers return structured `ApiError` envelopes consistently.
- Converted validation/timeout/auth/internal helper functions to produce `ApiError` values (e.g. `validation_error_response`, `internal_error_response`, `error_response`) and reused the `ApiError` mapping where applicable.
- Updated success DTO shapes in `src/service/api_models.rs` so health, create-probe, and get-probe responses follow the documented envelope shape (`meta` + `data`) and wired the handlers to return those envelopes.
- Tightened `GET /api/v1/probes/{id}` validation to reject whitespace ids (now returns `400 invalid_probe_id`) so the documented 400 response is reachable at runtime.
- Updated and extended tests in `tests/rest_server_http_tests.rs` to assert runtime JSON envelope shapes for successes and full RFC-style problem-details for errors, and expanded `tests/api_contract_tests.rs` to assert `meta`/`data` envelope presence and that documented probe response codes are present in OpenAPI.

### Testing
- Ran `cargo fmt --all -- --check` and formatted updated files as needed (passed after formatting). 
- Attempted `cargo clippy --all-targets --all-features -- -D warnings` but it was blocked by the environment Rust toolchain (`rustc 1.87.0`) while the project/dependencies require `>=1.88.0` so clippy could not complete.
- Attempted `cargo test --all` and targeted tests `cargo test --test api_contract_tests --test rest_server_http_tests`, but test execution was blocked by the same Rust toolchain mismatch (tests could not be run to completion in this environment).
- Unit-level sanity checks included running `cargo fmt` and local file formatting/lint adjustments; the new/updated tests assert the documented body shapes and the newly-reachable `400` path (observed in code and test assertions even though full `cargo test` could not complete due to toolchain constraints).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8459e576c8330855225756528ff47)