### PR TITLE
Update REST API docs from planned to released

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Windows MTR is built with enterprise-level security practices:
 - 🧪 Comprehensive fuzzing with 1000+ malformed packet tests
 - 🔑 Cryptographically signed releases with SHA-256 verification
 
-### REST API security and operational limits (v1 plan)
+### REST API security and operational limits (v1, implemented)
 
-For REST API mode (`mtr --api`), the security baseline is:
+For REST API mode (`mtr --api`), the enforced security baseline is:
 
-- Default bind address: `127.0.0.1:3000` (localhost only)
+- Default bind address: `127.0.0.1:3000` (localhost only, enforced)
 - Non-local bind requires explicit opt-in + authentication (`X-API-Key` or mTLS)
 - Default request timeout: `10s`
 - Max concurrent probes: `8`

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,7 +137,7 @@ mtr --trippy-flags "--log-format json --verbose --tui-refresh-rate 150ms" 8.8.8.
 ![Default mode demo](assets/windows-mtr-m.gif)
 ![Enhanced mode demo](assets/windows-mtr-upscaled.gif)
 
-## REST API startup and operational limits (v1)
+## REST API startup and operational limits (v1, implemented)
 
 Use API mode from the main binary and keep these defaults unless you have a reviewed reason to change them:
 
@@ -156,7 +156,7 @@ mtr --api --api-bind 127.0.0.1:4000
 - Max targets per request: `8`
 - Max request body size: `16 KiB`
 
-Authentication decision for v1:
+Authentication enforcement in v1:
 - Local-only bind: `none-local-only` is acceptable
 - Non-local bind: require `X-API-Key` or mTLS
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,7 +25,7 @@ For release-by-release details, see the [changelog](../CHANGELOG.md).
 | CI matrix coverage (Windows + Ubuntu, MSRV + stable) | ✅ Released | v1.2.x |
 | CodeQL workflow for Rust | ✅ Released | v1.2.x |
 | Container publishing to GHCR + Docker Hub | ✅ Released | v1.2.x |
-| REST API | 📅 Planned | H2 2026 |
+| REST API | ✅ Released | v1.2.x (released in the H2 2026 delivery window) |
 | SNMP Integration | 📅 Planned | H2 2026 |
 | Native Ratatui UI (tabs, hop table, charts) | ✅ Released (`--ui native`) | H2 2026 |
 | ETW + Windows observability integrations | 🛣️ Roadmap | H2 2026 |

--- a/docs/security/rest-api.md
+++ b/docs/security/rest-api.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This document defines baseline security assumptions and controls for the planned windows-mtr REST API v1.
+This document defines baseline security assumptions and controls for the implemented windows-mtr REST API v1.
 
 ## Assets
 


### PR DESCRIPTION
### Motivation
- Align release-facing documentation with the repository state by reflecting that the REST API is implemented and tested in-code so users and operators see accurate security defaults, operational limits, and roadmap status.

### Description
- Updated `README.md`, `USAGE.md`, `docs/security/rest-api.md`, and `docs/ROADMAP.md` to change REST API wording from "planned" to implemented/released, clarified the enforced localhost default bind (`127.0.0.1:3000`), adjusted authentication wording to reflect enforcement (`X-API-Key` or mTLS for non-local binds), and added a `v1.2.x` / H2 2026 release note in the roadmap; this is documentation-only and preserves runtime behavior, auth defaults, response envelope shape, and operational limits (10s timeout, max 8 concurrent probes, max 8 targets, 16 KiB payload).

### Testing
- Ran `cargo fmt --all -- --check` (passed) and attempted `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test --all`, both of which were blocked by the environment Rust toolchain (`rustc 1.87.0`) while the project and some dependencies require `rustc 1.88.0` (these checks should pass in CI or an environment with Rust >= 1.88.0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85fe40e948330b4da323d7134da22)