### PR TITLE
Align release notes labels with auto-labeler sources

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,7 +4,8 @@
 # Controls how GitHub groups merged PRs in automatically generated changelogs.
 # Used when `gh release create --generate-notes` targets this repository.
 #
-# Keep labels aligned with `.github/label-taxonomy.yml` to avoid drift.
+# Labels in categories are intentionally aligned with `.github/labeler.yml`
+# (path labels) and `.github/label-taxonomy.yml` (title-prefix labels).
 # Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 # =============================================================================
 


### PR DESCRIPTION
### Motivation
- Make release-note category labels explicit and aligned with the repository's auto-labeler sources to reduce taxonomy drift.

### Description
- Update `.github/release.yml` header comments to state that categories are intentionally aligned with `.github/labeler.yml` (path labels) and `.github/label-taxonomy.yml` (title-prefix labels), with no functional changes to mappings.

### Testing
- Parsed the updated YAML with `ruby -ryaml -e 'YAML.load_file(".github/release.yml")'`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8621123cc8330926af6a0b42c8cb2)