### PR TITLE
Clarify none-local-only auth strategy violation (403) and update docs/tests

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -50,6 +50,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthResponse'
+        '401':
+          description: Authentication required (for example missing API key or missing mTLS identity)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Authentication/authorization policy denied (for example `auth_strategy_violation`, invalid API key, or untrusted mTLS ingress)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/probes:
     post:
       summary: Start a probe job
@@ -81,6 +93,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateProbeResponse'
+        '401':
+          description: Authentication required (for example missing API key or missing mTLS identity)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Authentication/authorization policy denied (for example `auth_strategy_violation`, invalid API key, or untrusted mTLS ingress)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '400':
           description: Invalid request payload
           content:
@@ -122,6 +146,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetProbeResponse'
+        '401':
+          description: Authentication required (for example missing API key or missing mTLS identity)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Authentication/authorization policy denied (for example `auth_strategy_violation`, invalid API key, or untrusted mTLS ingress)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '400':
           description: Invalid probe id
           content:

--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -41,6 +41,7 @@ enum RequestAuthError {
     InvalidApiKey,
     MissingMtlsIdentity,
     UntrustedMtlsIngress,
+    NoneLocalOnlyRemoteAccessDenied,
 }
 
 impl RequestAuthError {
@@ -71,6 +72,14 @@ impl RequestAuthError {
                 title: "Forbidden",
                 detail: "mTLS identity headers are accepted only from trusted loopback ingress"
                     .to_string(),
+            },
+            Self::NoneLocalOnlyRemoteAccessDenied => ApiError {
+                status: StatusCode::FORBIDDEN,
+                code: "auth_strategy_violation",
+                title: "Remote access not allowed for none-local-only",
+                detail:
+                    "auth strategy none-local-only permits requests only from loopback addresses"
+                        .to_string(),
             },
         }
     }
@@ -677,7 +686,9 @@ fn enforce_request_auth(
 
     match config.auth_strategy {
         AuthStrategy::NoneLocalOnly if request_is_loopback => Ok(()),
-        AuthStrategy::NoneLocalOnly => Err(RequestAuthError::MissingApiKeyHeader.into_api_error()),
+        AuthStrategy::NoneLocalOnly => {
+            Err(RequestAuthError::NoneLocalOnlyRemoteAccessDenied.into_api_error())
+        }
         AuthStrategy::ApiKey => {
             let provided = headers
                 .get(API_KEY_HEADER)

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -628,6 +628,28 @@ async fn api_key_auth_rejects_missing_or_invalid_key_and_accepts_valid_key() {
 }
 
 #[tokio::test]
+async fn none_local_only_auth_rejects_non_loopback_requests_with_strategy_violation() {
+    let config = RestApiConfig {
+        auth_strategy: AuthStrategy::NoneLocalOnly,
+        ..RestApiConfig::default()
+    };
+
+    let (status, body) = request_health_with_connect_info(
+        config,
+        SocketAddr::from((IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)), 43120)),
+        None,
+    )
+    .await;
+
+    assert_eq!(status, axum::http::StatusCode::FORBIDDEN);
+    assert_error_shape(&body, 403, "auth_strategy_violation");
+    assert_eq!(
+        body["error"]["detail"],
+        "auth strategy none-local-only permits requests only from loopback addresses"
+    );
+}
+
+#[tokio::test]
 async fn mtls_auth_accepts_identity_header_from_loopback_ingress() {
     let config = RestApiConfig {
         auth_strategy: AuthStrategy::Mtls,


### PR DESCRIPTION
### Motivation
- Make policy failures explicit by returning a dedicated error for `AuthStrategy::NoneLocalOnly` when a request originates from a non-loopback address instead of reusing `missing_api_key`, and ensure the HTTP status and API problem fields reflect an authorization/policy denial.

### Description
- Added `RequestAuthError::NoneLocalOnlyRemoteAccessDenied` and mapped it to an `ApiError` with `status: 403`, `code: "auth_strategy_violation"`, `title: "Remote access not allowed for none-local-only"`, and a clear `detail` message.
- Updated `enforce_request_auth` to return the new error for non-loopback requests when `config.auth_strategy == AuthStrategy::NoneLocalOnly`.
- Added a test `none_local_only_auth_rejects_non_loopback_requests_with_strategy_violation` in `tests/rest_server_http_tests.rs` that asserts status `403`, the `auth_strategy_violation` code, and the exact detail string.
- Updated `docs/api/openapi.yaml` to include `401` and `403` responses for `GET /api/v1/health`, `POST /api/v1/probes`, and `GET /api/v1/probes/{id}` so the OpenAPI docs reflect authentication/authorization outcomes.

### Testing
- Ran `cargo fmt --all` to apply formatting changes after an initial `--check` reported a diff, and formatting completed successfully.
- Attempted `cargo test --test rest_server_http_tests`, but tests could not be executed in this environment due to a Rust toolchain mismatch (`rustc 1.87.0` while the project requires `>=1.88.0`), so the new test was added but not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdeab2466883309d8ff75362f3eaaa)