### PR TITLE
Print interactive troubleshooting hint on non-zero exit and clarify portable executable usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See [docs/security/rest-api.md](docs/security/rest-api.md) for the full threat m
 
 1. Download `windows-mtr-x86_64.exe` (direct executable) or `windows-mtr-official-x86_64.zip` (official portable bundle) from [GitHub Releases](https://github.com/benjisho/windows-mtr/releases)
 2. Extract the ZIP file if you chose the portable bundle
-3. Run `mtr.exe` directly - no installation required
+3. Run the downloaded executable directly (for example `windows-mtr-x86_64.exe 8.8.8.8`) or rename it to `mtr.exe` for shorter commands
 
 #### System Requirements
 
@@ -200,6 +200,9 @@ Windows MTR requires administrator privileges to run properly, as it needs to se
 ```bash
 mtr 8.8.8.8
 ```
+
+> [!TIP]
+> If you downloaded a standalone `.exe` and did not install via MSI, use that filename directly (for example `windows-mtr-x86_64.exe 8.8.8.8`) unless you renamed it to `mtr.exe`.
 
 ### Native Ratatui UI (live hops + table + charts)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -6,6 +6,8 @@
 mtr [options] <hostname-or-ip>
 ```
 
+> On Windows portable downloads, replace `mtr` with your actual executable name (for example `windows-mtr-x86_64.exe`).
+
 ## Core Options
 
 | Option | Description |

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,13 @@ fn should_print_banner(args: &Cli) -> bool {
     !args.api && json_output_from_cli(&args.trace).is_none()
 }
 
+fn should_print_interactive_troubleshooting_hint(request: &ProbeRequest, exit_code: i32) -> bool {
+    request.ui_mode == UiMode::Default
+        && !request.report
+        && request.json_output.is_none()
+        && exit_code != 0
+}
+
 fn print_banner() {
     println!("windows-mtr by Benji Shohet (benjisho) — https://github.com/benjisho/windows-mtr");
 }
@@ -446,6 +453,16 @@ fn main() -> anyhow::Result<()> {
         EMBEDDED_TRIPPY_ENV,
     )
     .context("failed to run embedded trippy")?;
+
+    if should_print_interactive_troubleshooting_hint(&request, result.exit_code) {
+        eprintln!(
+            "windows-mtr interactive mode exited with code {}.\n\
+             Try report mode to validate probe execution: `mtr -r -c 5 {}`.\n\
+             If report mode also fails, verify Administrator privileges and local firewall/security policy.",
+            result.exit_code, plan.validated_host
+        );
+    }
+
     process::exit(result.exit_code);
 }
 
@@ -459,6 +476,47 @@ mod tests {
         let cli = Cli::try_parse_from(["mtr", "--api"]).expect("api mode should parse");
         assert!(cli.api);
         assert!(cli.trace.host.is_none());
+    }
+
+    #[test]
+    fn interactive_troubleshooting_hint_only_for_default_interactive_failures() {
+        let request = ProbeRequest {
+            host: "8.8.8.8".to_string(),
+            tcp: false,
+            udp: false,
+            port: None,
+            source_port: None,
+            report: false,
+            json_output: None,
+            count: None,
+            interval_seconds: None,
+            timeout_seconds: None,
+            report_wide: false,
+            no_dns: false,
+            max_hops: None,
+            show_asn: false,
+            dns_lookup_as_info: false,
+            packet_size: None,
+            src: None,
+            interface: None,
+            ecmp: None,
+            dns_cache_ttl_seconds: None,
+            trippy_flags: None,
+            ui_mode: UiMode::Default,
+            enhanced_ui: EnhancedUiConfig {
+                latency_warn_ms: 100.0,
+                latency_bad_ms: 250.0,
+                loss_warn_pct: 2.0,
+                loss_bad_pct: 5.0,
+                row_coloring: true,
+                sparklines: true,
+                summary: true,
+            },
+            has_enhanced_overrides: false,
+        };
+
+        assert!(should_print_interactive_troubleshooting_hint(&request, 1));
+        assert!(!should_print_interactive_troubleshooting_hint(&request, 0));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provide a helpful troubleshooting hint when the default interactive UI exits with a non-zero code so users know to try report mode or check permissions.
- Clarify README and USAGE guidance for portable downloads so users know how to run the standalone executable when not installed via MSI.

### Description
- Add `should_print_interactive_troubleshooting_hint` and invoke it after running the embedded Trippy process to conditionally print an `eprintln!` with a suggested `mtr -r -c 5 <host>` command and common checks (Administrator privileges and firewall/security policy).
- Update `README.md` to document running the downloaded executable directly (example `windows-mtr-x86_64.exe 8.8.8.8`) and add a tip about portable `.exe` usage in the Quick Start.
- Update `USAGE.md` to note replacing `mtr` with the actual portable executable name (example `windows-mtr-x86_64.exe`).
- Add unit test `interactive_troubleshooting_hint_only_for_default_interactive_failures` to validate the hint condition logic.

### Testing
- Ran `cargo test` including the new `interactive_troubleshooting_hint_only_for_default_interactive_failures` unit test and existing CLI parsing tests.
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04ebc5e608330a9e695007bee4c09)