### PR TITLE
Add Codex hooks for session context, pre/post tool policies and update AGENTS.md

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "name": "windows-mtr session context",
+        "command": "bash -lc 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); python3 \"$ROOT/.codex/hooks/session_start_context.py\"'"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "name": "windows-mtr bash safety policy",
+        "tool": "Bash",
+        "command": "bash -lc 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); python3 \"$ROOT/.codex/hooks/pre_tool_use_policy.py\"'"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "name": "windows-mtr bash reminder review",
+        "tool": "Bash",
+        "command": "bash -lc 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); python3 \"$ROOT/.codex/hooks/post_tool_use_review.py\"'"
+      }
+    ]
+  }
+}

--- a/.codex/hooks/README.md
+++ b/.codex/hooks/README.md
@@ -1,0 +1,20 @@
+# Codex hooks for `windows-mtr`
+
+This directory contains **Codex-specific repository tooling** for maintainer workflow support.
+
+It does **not** change Windows-MTR product/runtime behavior. Hooks only influence Codex session guidance and Bash tool policy/review.
+
+## Files
+- `session_start_context.py`: emits short repo-specific startup context (safety, validation loop, docs expectations).
+- `pre_tool_use_policy.py`: conservatively blocks clearly risky Bash actions (force-push, hard reset, destructive clean/remove, accidental release-style tag creation).
+- `post_tool_use_review.py`: emits lightweight reminders only when changed files suggest useful follow-up checks.
+
+## Design limitations
+- Hooks intentionally use a small policy surface to avoid over-blocking normal development.
+- Logic is stdlib-only Python for deterministic behavior and easy review.
+- Scripts are defensive around missing/invalid JSON input and missing git context.
+
+## Disable or adjust
+- Disable all hooks by removing or renaming `.codex/hooks.json`.
+- Tune policy/reminders by editing individual scripts under `.codex/hooks/`.
+- Keep changes focused and aligned with root `AGENTS.md` plus repository docs.

--- a/.codex/hooks/post_tool_use_review.py
+++ b/.codex/hooks/post_tool_use_review.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Lightweight post-tool reminder layer for Bash activity."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Iterable
+
+
+def load_input() -> dict:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def changed_files_from_git() -> list[str]:
+    try:
+        out = subprocess.check_output(
+            ["git", "status", "--porcelain"], text=True, stderr=subprocess.DEVNULL
+        )
+    except Exception:
+        return []
+
+    files: list[str] = []
+    for line in out.splitlines():
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        files.append(path)
+    return files
+
+
+def has_prefix(paths: Iterable[str], prefix: str) -> bool:
+    return any(p.startswith(prefix) for p in paths)
+
+
+def has_suffix(paths: Iterable[str], suffix: str) -> bool:
+    return any(p.endswith(suffix) for p in paths)
+
+
+def main() -> int:
+    _payload = load_input()
+    paths = changed_files_from_git()
+    if not paths:
+        print(json.dumps({}))
+        return 0
+
+    reminders: list[str] = []
+
+    if has_prefix(paths, "src/") or has_prefix(paths, "tests/") or has_prefix(paths, "examples/") or has_prefix(paths, "xtask/"):
+        reminders.append(
+            "Rust code changed: run cargo fmt/clippy/test loop before finalizing."
+        )
+
+    if has_prefix(paths, ".github/workflows/") or "Dockerfile" in paths:
+        reminders.append(
+            "Workflow/Docker scope changed: keep edits minimal and run workflow hygiene checks (e.g., pre-commit/actionlint) when available."
+        )
+
+    if has_suffix(paths, ".md"):
+        reminders.append(
+            "Markdown changed: ensure docs remain aligned with behavior and run markdown/pre-commit checks if available."
+        )
+
+    if "docs/api/openapi.yaml" in paths or "scripts/validate_openapi_schema.py" in paths or "scripts/check_openapi_compat.sh" in paths:
+        reminders.append(
+            "OpenAPI-related files changed: run schema validation and compatibility checks as appropriate."
+        )
+
+    if not reminders:
+        print(json.dumps({}))
+        return 0
+
+    message = "Post-tool reminders:\n- " + "\n- ".join(reminders)
+    print(json.dumps({"additionalContext": message}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/pre_tool_use_policy.py
+++ b/.codex/hooks/pre_tool_use_policy.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Conservative pre-tool policy checks for Bash commands."""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Rule:
+    pattern: re.Pattern[str]
+    reason: str
+
+
+DENY_RULES: tuple[Rule, ...] = (
+    Rule(re.compile(r"\bgit\s+push\b[^\n]*\s--force(?:\b|=)"), "Refusing force push in routine repo work."),
+    Rule(re.compile(r"\bgit\s+push\b[^\n]*\s-f\b"), "Refusing force push in routine repo work."),
+    Rule(re.compile(r"\bgit\s+reset\s+--hard\b"), "Refusing hard reset because it can destroy local work."),
+    Rule(re.compile(r"\bgit\s+clean\s+-fdx\b"), "Refusing git clean -fdx because it can remove untracked files irreversibly."),
+    Rule(re.compile(r"\brm\s+-rf\s+(/\s*|~\s*|\.\.?\s*$|\*)"), "Refusing broad destructive rm -rf target."),
+    Rule(re.compile(r"\bgit\s+tag\b[^\n]*\s(-a\s+)?v\d"), "Tag creation is release-sensitive; require explicit maintainer request."),
+)
+
+
+def load_input() -> dict:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def extract_command(payload: dict) -> str:
+    for key in ("command", "input", "cmd"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    tool_input = payload.get("toolInput")
+    if isinstance(tool_input, dict):
+        for key in ("command", "cmd"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    return ""
+
+
+def main() -> int:
+    payload = load_input()
+    command = extract_command(payload)
+    normalized = " ".join(shlex.split(command)) if command else ""
+
+    if not normalized:
+        print(json.dumps({"decision": "allow"}))
+        return 0
+
+    for rule in DENY_RULES:
+        if rule.pattern.search(normalized):
+            print(json.dumps({"decision": "deny", "reason": rule.reason}))
+            return 0
+
+    print(json.dumps({"decision": "allow"}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/session_start_context.py
+++ b/.codex/hooks/session_start_context.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Emit short repo-specific context at Codex session start."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def git_root() -> Path:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+        if out:
+            return Path(out)
+    except Exception:
+        pass
+    return Path.cwd()
+
+
+def main() -> int:
+    root = git_root()
+    agents = root / "AGENTS.md"
+
+    lines = [
+        "windows-mtr Codex context:",
+        "- Keep diffs focused and preserve CLI/runtime compatibility unless explicitly requested.",
+        "- For Rust changes, run: cargo fmt --all -- --check; cargo clippy --all-targets --all-features -- -D warnings; cargo test --all.",
+        "- Update docs for CLI/output/API/install/release behavior changes (README/USAGE/docs/CHANGELOG as relevant).",
+        "- Treat workflow/release/security-related edits as high-sensitivity and minimize scope.",
+        "- Run OpenAPI checks only when API contract/spec changed: python3 scripts/validate_openapi_schema.py and scripts/check_openapi_compat.sh <base-ref>.",
+    ]
+
+    if not agents.exists():
+        lines.append("- Note: AGENTS.md not found at git root; rely on repository docs/instructions.")
+
+    print(json.dumps({"additionalContext": "\n".join(lines)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,62 @@
 # AGENTS.md
 
-This file provides instructions for autonomous coding agents working in this repository.
+Codex operating notes for `windows-mtr` (repository scope).
 
-## 1) Mission and contribution goals
-- Keep `windows-mtr` reliable, secure, and predictable for networking diagnostics.
+## Mission and guardrails
+- Keep `windows-mtr` reliable, secure, and predictable for network diagnostics.
 - Prefer small, reviewable pull requests with clear user impact.
-- Preserve CLI compatibility unless change is explicitly documented.
+- Preserve CLI compatibility unless a change is explicitly requested and documented.
 
-## 2) Required workflow for every change
-1. **Understand context first**
-   - Read `README.md`, `USAGE.md`, and relevant source/tests before editing.
-2. **Plan before editing**
-   - Identify affected modules, risks, and validation steps.
-3. **Implement minimal safe change**
-   - Avoid broad refactors unless required by the task.
-4. **Validate locally**
-   - Run formatting, linting, and tests relevant to touched code.
-5. **Document and summarize**
-   - Update docs/changelog when behavior or UX changes.
+## Required workflow
+1. Read context first: `README.md`, `USAGE.md`, and touched source/tests/docs.
+2. Plan a minimal safe diff (avoid unrelated refactors).
+3. Implement with explicit error handling and no silent network fallbacks.
+4. Validate with relevant checks.
+5. Update docs/changelog when behavior, UX, install, API, or release flow changes.
 
-## 3) Repository map
-- `src/` — application source.
-- `tests/` — integration/unit/report tests and fixtures.
+## Repository map
+- `src/` — application code.
+- `tests/` — integration/unit/report tests.
 - `examples/` — sample usage.
-- `xtask/` — project automation helpers.
-- `README.md` and `USAGE.md` — user documentation and commands.
+- `xtask/` — automation helpers.
+- `docs/` — project documentation.
 
-## 4) Coding standards
-- Follow existing Rust style and naming patterns in nearby files.
-- Prioritize correctness and explicit error handling over cleverness.
-- Do not introduce silent fallbacks for network errors without justification.
-- Keep functions cohesive and avoid unnecessary public surface expansion.
-- Add or update tests for bug fixes and behavior changes.
+## Toolchain and validation
+- Rust/toolchain expectations follow repo docs and CI (currently Rust 1.88.0+ / MSRV from `Cargo.toml`).
+- For Rust changes, run when available:
+  - `cargo fmt --all -- --check`
+  - `cargo clippy --all-targets --all-features -- -D warnings`
+  - `cargo test --all`
+- For workflow/docs hygiene changes, run targeted checks (for example `pre-commit run --all-files`, `actionlint`, markdown lint).
+- If a command cannot run, report the exact command and concrete environment blocker.
 
-## 5) Testing and quality gates
-When available, prefer running these commands before finalizing:
+## API/OpenAPI checks (when API contract/spec changes)
+- `python3 scripts/validate_openapi_schema.py`
+- `scripts/check_openapi_compat.sh <base-ref>`
 
-```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all
-```
+## Security and sensitive-change caution
+- Treat CLI args, hostnames, packet data, and files as untrusted inputs.
+- Avoid logging sensitive data or adding telemetry/data-exfil behavior.
+- Keep dependencies minimal and justified.
+- Use extra care and minimal diffs for:
+  - `.github/workflows/**`, release/version/tagging/packaging automation.
+  - Security policy/audit/dependency configuration.
 
-If a command is not runnable in the environment, report exactly why.
-
-## 6) Security and safety rules
-- Treat all external inputs (CLI args, hostnames, packets, files) as untrusted.
-- Avoid logging sensitive data or unnecessary host-identifying details.
-- Do not add telemetry, network beacons, or data exfiltration behavior.
-- Keep dependencies minimal; justify and document any new dependency.
-
-## 7) Performance guidelines
-- Be mindful of hot paths in probe/report loops.
-- Avoid needless allocations and blocking operations in frequently executed paths.
-- Include a short performance note in PRs for non-trivial algorithmic changes.
-
-## 8) Documentation expectations
-Update docs when any of these change:
+## Documentation expectations
+Update docs when changing:
 - CLI flags/options/defaults.
-- Output formats or report fields.
-- Installation/build/run instructions.
+- Output/report/API schema.
+- Build/install/run/release behavior.
 
-## 9) Commit and PR guidance
-- Use imperative, specific commit messages.
-- PR descriptions should include:
-  - What changed.
-  - Why it changed.
-  - How it was tested.
-  - Any compatibility or risk notes.
+Primary docs typically include `README.md`, `USAGE.md`, `docs/`, and `CHANGELOG.md`.
 
-## 10) Non-goals and restrictions
+## Non-goals
 - Do not rewrite large modules unless explicitly requested.
-- Do not change license or legal notices without maintainer instruction.
+- Do not change license/legal notices without maintainer instruction.
 - Do not commit generated artifacts unless repository convention requires it.
 
-## 11) GitHub automation files
-- Keep Copilot guidance in `.github/copilot-instructions.md`.
-- Keep role-specific agent specs in `.github/agents/`.
-- Keep path-specific Copilot rules in `.github/instructions/*.instructions.md` using `applyTo`.
-- Ensure agent specs define scope, prohibited actions, validation, and output contract.
-
-## 12) Repository-local skills
-- Place project-specific skills under `skills/<skill-name>/SKILL.md`.
-- Keep skill metadata concise and trigger-oriented; move long details into `references/`.
-- Prefer narrow skills that automate repeatable tasks (diagnostics, release prep, docs sync).
-- Reuse scripts/templates from a skill directory instead of duplicating long instructions.
+## Repo instruction surfaces
+- `.github/copilot-instructions.md` — repository-wide assistant guidance.
+- `.github/instructions/*.instructions.md` — path-scoped rules.
+- `.github/agents/` — role-specific agent specs.
+- `skills/<skill-name>/SKILL.md` — repeatable repository-local workflows.


### PR DESCRIPTION
### Motivation
- Provide repository-specific Codex guidance at session start and conservative safety checks around Bash tool usage to reduce accidental destructive actions.
- Emit lightweight post-tool reminders based on changed files to surface follow-up validation steps for common areas (Rust, workflows, OpenAPI, docs).
- Consolidate and clarify repository operating notes and guardrails in `AGENTS.md` to match the hook guidance and project validation expectations.

### Description
- Add `.codex/hooks.json` to register three hooks and include tooling-specific commands that run the accompanying Python scripts.
- Add `session_start_context.py` to emit short repo-specific startup context and guidance via `additionalContext` JSON output.
- Add `pre_tool_use_policy.py` to block clearly risky Bash commands by returning `{"decision":"deny","reason":...}` for matches and otherwise allow; it inspects incoming JSON payloads and normalizes commands.
- Add `post_tool_use_review.py` to inspect changed files from `git status --porcelain` and emit an `additionalContext` JSON message with targeted reminders for Rust, workflows/Docker, Markdown, and OpenAPI changes, and add a README explaining the hooks and how to adjust or disable them.
- Update `AGENTS.md` to reorganize and clarify mission, required workflow, toolchain/validation commands, OpenAPI checks, and other guardrails for the repository.

### Testing
- No automated tests were executed for these added hook scripts in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ec84b92c83308b88645d2028ec00)