### PR TITLE
native-ui: show elapsed awaiting-data time and 15s timeout troubleshooting hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Updated README/USAGE roadmap and examples to document the new native UI preview and controls.
+- Improved the native UI help footer to show elapsed "awaiting data" time and add a 15-second timeout troubleshooting prompt when hop snapshots never arrive.
 
 ## [1.1.3] - 2026-02-28
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -49,7 +49,7 @@ Controls:
 - `←` switch to previous tab
 - `q` quit
 
-When probe snapshots fail repeatedly, the help footer surfaces the latest poll error and live troubleshooting hints (run with Administrator privileges, review firewall policy, or try report mode with `-r`).
+When probe snapshots fail repeatedly, the help footer surfaces the latest poll error and live troubleshooting hints (run with Administrator privileges, review firewall policy, or try report mode with `-r`). If no hop data is detected for 15 seconds, the footer also prompts you to quit (`q`) and retry in report mode for immediate diagnostics.
 
 `--ui native` accepts the standard probe and output tuning options, and renders them in the native Ratatui view.
 

--- a/src/native_ui.rs
+++ b/src/native_ui.rs
@@ -19,7 +19,7 @@ use std::io::{self, Stdout};
 use std::process::Command;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const EMBEDDED_TRIPPY_ENV: &str = "WINDOWS_MTR_EMBEDDED_TRIPPY";
 
@@ -39,6 +39,7 @@ pub struct NativeUiApp {
     hops: Vec<HopStat>,
     latency_history: Vec<(f64, f64)>,
     loss_history: Vec<(f64, f64)>,
+    started_at: Instant,
     last_error: Option<String>,
     consecutive_poll_failures: u32,
 }
@@ -51,6 +52,7 @@ impl NativeUiApp {
             hops: Vec::new(),
             latency_history: Vec::new(),
             loss_history: Vec::new(),
+            started_at: Instant::now(),
             last_error: None,
             consecutive_poll_failures: 0,
         }
@@ -405,6 +407,13 @@ fn build_help_text(app: &NativeUiApp) -> String {
     let base = "Controls: ←/→ or Tab switch tabs • q quits";
     let mut notes = Vec::new();
 
+    if app.hops.is_empty() {
+        notes.push(format!(
+            "Awaiting hop data for {}s",
+            app.started_at.elapsed().as_secs()
+        ));
+    }
+
     if let Some(err) = &app.last_error {
         notes.push(format!("Last poll error: {err}"));
     }
@@ -412,6 +421,13 @@ fn build_help_text(app: &NativeUiApp) -> String {
     if app.hops.is_empty() && app.consecutive_poll_failures >= 3 {
         notes.push(
             "No hops yet. Try running as Administrator, checking firewall policy, or using report mode (-r)."
+                .to_string(),
+        );
+    }
+
+    if app.hops.is_empty() && app.started_at.elapsed().as_secs() >= 15 {
+        notes.push(
+            "Still no data after 15s. Press q to quit and retry with report mode (-r) for immediate diagnostics."
                 .to_string(),
         );
     }
@@ -631,14 +647,17 @@ mod tests {
     #[test]
     fn build_help_text_includes_live_troubleshooting_when_ui_has_no_data() {
         let mut app = NativeUiApp::new("example.com");
+        app.started_at = Instant::now() - Duration::from_secs(16);
         app.ingest_error(anyhow!("poll failed"));
         app.ingest_error(anyhow!("poll failed"));
         app.ingest_error(anyhow!("poll failed"));
 
         let help = build_help_text(&app);
+        assert!(help.contains("Awaiting hop data for"));
         assert!(help.contains("Last poll error: poll failed"));
         assert!(help.contains("No hops yet."));
         assert!(help.contains("report mode (-r)"));
+        assert!(help.contains("Still no data after 15s."));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Improve the native Ratatui UI feedback when the embedded probe (trippy) never returns hop snapshots, so users are not left with an ambiguous “Awaiting data…” message.\
- Provide a quick interactive remediation hint (quit + report mode) after a short timeout to help capture immediate diagnostics without leaving users trapped in the TUI.

### Description
- Added `started_at: Instant` to `NativeUiApp` to track how long the UI has been waiting for hop data and initialized it in `NativeUiApp::new`. (modified `src/native_ui.rs`)\
- Extended the UI help/footer builder to include an elapsed “Awaiting hop data for Ns” message when no hops are present, and a 15-second timeout hint recommending `q` to quit and retry in report mode (`-r`) when no data arrives. (modified `src/native_ui.rs`)\
- Updated the native UI unit test `build_help_text_includes_live_troubleshooting_when_ui_has_no_data` to validate the new elapsed-time text and the 15s timeout prompt. (modified `src/native_ui.rs` tests)\
- Documented the new 15-second no-data prompt in `USAGE.md` and recorded the change in `CHANGELOG.md` under Unreleased. (modified `USAGE.md`, `CHANGELOG.md`)

### Testing
- Ran `cargo fmt --all -- --check` which succeeded in this environment.\
- Attempted `cargo clippy --all-targets --all-features -- -D warnings` but it failed due to the local toolchain being `rustc 1.87.0` while the project/MSRV requires `rustc 1.88.0`; exact blocker reported by clippy output.\
- Attempted `cargo test --all` but it could not run for the same toolchain mismatch (`rustc 1.87.0` vs MSRV `1.88.0`); tests were not executed here.\
- Note: unit tests were updated to cover the new help/footer behavior (`build_help_text_includes_live_troubleshooting_when_ui_has_no_data`) but their execution is blocked by the environment toolchain mismatch described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77c085f688330aa2e39e3406961a1)