### PR TITLE
Mask internal probe errors, prune completed jobs on get, and adjust mTLS message

### DIFF
--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -628,7 +628,7 @@ async fn get_probe(
             ));
         }
 
-        let store = state
+        let mut store = state
             .store
             .lock()
             .map_err(|_| internal_error_response("failed to lock probe store"))?;

--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -71,7 +71,7 @@ impl RequestAuthError {
                 status: StatusCode::FORBIDDEN,
                 code: "untrusted_mtls_ingress",
                 title: "Forbidden",
-                detail: "mTLS identity headers are accepted only from trusted loopback ingress"
+                detail: "mTLS identity headers are accepted only from trusted ingress sources"
                     .to_string(),
             },
             Self::NoneLocalOnlyRemoteAccessDenied => ApiError {
@@ -161,7 +161,8 @@ impl ProbeStore {
         self.prune(Instant::now());
     }
 
-    fn get(&self, id: &str) -> Option<ProbeJob> {
+    fn get(&mut self, id: &str) -> Option<ProbeJob> {
+        self.prune(Instant::now());
         self.jobs.get(id).cloned()
     }
 }
@@ -480,19 +481,21 @@ async fn execute_probe(
                 });
             }
             Ok(Err(error)) => {
+                eprintln!("probe execution failed for {validated_target}: {error}");
                 targets.push(validated_target.clone());
                 target_results.push(ProbeTargetExecutionResult {
                     target: validated_target,
                     success: false,
-                    error: Some(format!("probe execution failed: {error}")),
+                    error: Some("probe execution failed".to_string()),
                 });
             }
             Err(error) => {
+                eprintln!("probe task panicked for {validated_target}: {error}");
                 targets.push(validated_target.clone());
                 target_results.push(ProbeTargetExecutionResult {
                     target: validated_target,
                     success: false,
-                    error: Some(format!("probe task panicked: {error}")),
+                    error: Some("probe execution failed".to_string()),
                 });
             }
         }
@@ -502,13 +505,7 @@ async fn execute_probe(
     if !target_results.is_empty() && target_results.iter().all(|result| !result.success) {
         let error_details = target_results
             .iter()
-            .map(|result| {
-                let detail = result
-                    .error
-                    .as_deref()
-                    .unwrap_or("unknown probe execution error");
-                format!("{}: {detail}", result.target)
-            })
+            .map(|result| format!("{}: probe execution failed", result.target))
             .collect::<Vec<_>>()
             .join("; ");
         return Err(format!("all target probes failed: {error_details}"));
@@ -659,7 +656,7 @@ async fn run_with_timeout<T>(
             StatusCode::REQUEST_TIMEOUT,
             "request_timeout",
             "Request timed out",
-            format!("request processing exceeded timeout of {duration:?}"),
+            "request processing timed out".to_string(),
         )),
     }
 }

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -275,7 +275,9 @@ async fn create_probe_transitions_through_queued_running_and_completed() {
                 .as_str()
                 .expect("error text should exist for failed probe");
             assert!(
-                error.contains("privileges are required") || error.contains("exit code 1"),
+                error.contains("probe execution failed")
+                    || error.contains("privileges are required")
+                    || error.contains("exit code 1"),
                 "unexpected failure details for unprivileged environment: {terminal}"
             );
         }

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -275,7 +275,9 @@ async fn create_probe_transitions_through_queued_running_and_completed() {
                 .as_str()
                 .expect("error text should exist for failed probe");
             assert!(
-                error.contains("probe execution failed")
+                (error.contains("all target probes failed")
+                    && error.contains("127.0.0.1")
+                    && error.contains("probe execution failed"))
                     || error.contains("privileges are required")
                     || error.contains("exit code 1"),
                 "unexpected failure details for unprivileged environment: {terminal}"

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -135,14 +135,25 @@ async fn create_probe(
 }
 
 async fn fetch_probe(client: &reqwest::Client, addr: SocketAddr, id: &str) -> serde_json::Value {
+    let (status, body) = fetch_probe_response(client, addr, id).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    body
+}
+
+async fn fetch_probe_response(
+    client: &reqwest::Client,
+    addr: SocketAddr,
+    id: &str,
+) -> (reqwest::StatusCode, serde_json::Value) {
     let get_res = client
         .get(format!("http://{addr}/api/v1/probes/{id}"))
         .send()
         .await
         .expect("get probe request should succeed");
 
-    assert_eq!(get_res.status(), reqwest::StatusCode::OK);
-    get_res.json().await.expect("json body expected")
+    let status = get_res.status();
+    let body = get_res.json().await.expect("json body expected");
+    (status, body)
 }
 
 async fn wait_for_probe_status(
@@ -684,6 +695,12 @@ async fn mtls_auth_rejects_identity_header_from_untrusted_non_loopback_ingress()
 
     assert_eq!(status, axum::http::StatusCode::FORBIDDEN);
     assert_error_shape(&body, 403, "untrusted_mtls_ingress");
+    assert!(
+        body["error"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("trusted ingress")
+    );
 }
 
 #[tokio::test]
@@ -755,6 +772,87 @@ async fn get_probe_returns_not_found_for_unknown_id() {
     assert_eq!(res.status(), reqwest::StatusCode::NOT_FOUND);
     let body: serde_json::Value = res.json().await.expect("json body expected");
     assert_error_shape(&body, 404, "probe_not_found");
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn expired_probe_returns_404_after_ttl() {
+    let config = RestApiConfig {
+        completed_job_ttl: Duration::from_millis(100),
+        ..RestApiConfig::default()
+    };
+    let (addr, shutdown) = spawn_server_with_config(config).await;
+    let client = build_http_client();
+
+    let created = create_probe(&client, addr, "definitely-not-a-real-host.invalid").await;
+    let id = created["data"]["id"]
+        .as_str()
+        .expect("id should be a string")
+        .to_string();
+
+    let _failed = wait_for_probe_status(&client, addr, &id, "failed").await;
+    sleep(Duration::from_millis(150)).await;
+
+    let (status, body) = fetch_probe_response(&client, addr, &id).await;
+    assert_eq!(status, reqwest::StatusCode::NOT_FOUND);
+    assert_error_shape(&body, 404, "probe_not_found");
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn retention_cap_evicts_oldest_completed_job() {
+    let config = RestApiConfig {
+        max_completed_jobs: 1,
+        ..RestApiConfig::default()
+    };
+    let (addr, shutdown) = spawn_server_with_config(config).await;
+    let client = build_http_client();
+
+    let first = create_probe(&client, addr, "definitely-not-a-real-host.invalid").await;
+    let first_id = first["data"]["id"]
+        .as_str()
+        .expect("id should be a string")
+        .to_string();
+    let _ = wait_for_probe_status(&client, addr, &first_id, "failed").await;
+
+    let second = create_probe(&client, addr, "definitely-not-a-real-host.invalid").await;
+    let second_id = second["data"]["id"]
+        .as_str()
+        .expect("id should be a string")
+        .to_string();
+    let _ = wait_for_probe_status(&client, addr, &second_id, "failed").await;
+
+    let (first_status, first_body) = fetch_probe_response(&client, addr, &first_id).await;
+    assert_eq!(first_status, reqwest::StatusCode::NOT_FOUND);
+    assert_error_shape(&first_body, 404, "probe_not_found");
+
+    let (second_status, second_body) = fetch_probe_response(&client, addr, &second_id).await;
+    assert_eq!(second_status, reqwest::StatusCode::OK);
+    assert_eq!(second_body["data"]["id"], second_id);
+
+    let _ = shutdown.send(());
+}
+
+#[tokio::test]
+async fn error_response_does_not_leak_internal_details() {
+    let (addr, shutdown) = spawn_server().await;
+    let client = build_http_client();
+
+    let created = create_probe(&client, addr, "definitely-not-a-real-host.invalid").await;
+    let id = created["data"]["id"]
+        .as_str()
+        .expect("id should be a string");
+
+    let failed = wait_for_probe_status(&client, addr, id, "failed").await;
+    let error = failed["data"]["error"]
+        .as_str()
+        .expect("error text should exist");
+
+    assert!(error.contains("probe execution failed"));
+    assert!(!error.contains("failed to build probe plan"));
+    assert!(!error.contains("No such file or directory"));
 
     let _ = shutdown.send(());
 }


### PR DESCRIPTION
### Motivation
- Prevent leaking internal runtime details from probe execution errors and make error responses generic and safer for clients.
- Ensure completed/expired probe jobs are pruned proactively when read to respect TTL and retention limits.
- Clarify the mTLS ingress error wording to accurately reflect trusted ingress sources.

### Description
- Replaced detailed probe failure strings with a generic "probe execution failed" message in `execute_probe` and suppressed internal error text, while emitting `eprintln!`-level logs for debugging.
- Consolidated aggregated error details to use the generic message (`"{target}: probe execution failed"`) instead of propagating internal errors.
- Made `ProbeStore::get` take `&mut self` and call `prune(Instant::now())` to evict expired/completed jobs on read so TTL and `max_completed_jobs` are enforced during retrievals.
- Changed the mTLS ingress error detail to "mTLS identity headers are accepted only from trusted ingress sources" for broader accuracy.
- Simplified the timeout error detail in `run_with_timeout` to "request processing timed out".
- Updated tests and helpers in `tests/rest_server_http_tests.rs`, added `fetch_probe_response` helper, and added integration tests: `expired_probe_returns_404_after_ttl`, `retention_cap_evicts_oldest_completed_job`, and `error_response_does_not_leak_internal_details`.

### Testing
- Ran the test suite with `cargo test` including the modified `tests/rest_server_http_tests.rs` integration tests and the new tests, and they passed. 
- Exercised the new TTL and retention behaviors via `expired_probe_returns_404_after_ttl` and `retention_cap_evicts_oldest_completed_job` which assert eviction and 404 behavior. 
- Verified error masking via `error_response_does_not_leak_internal_details` and an updated mTLS test (`mtls_auth_rejects_identity_header_from_untrusted_non_loopback_ingress`) which assert the adjusted error message content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc7193fb68833080843404d0703cc2)