### PR TITLE
Unify dashboard UI UX and canonical GitHub Release distribution flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,32 +383,6 @@ jobs:
             ~/.cargo/git
           cache-on-failure: true
 
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@6eb4471beed212309063862e6f5284ca3da3b01d # cargo-binstall
-
-      - name: Install trippy (prebuilt binary)
-        run: |
-          echo "Installing trippy prebuilt binary..."
-          cargo binstall trippy --no-confirm --locked
-
-          $cargoBin = if ($env:CARGO_HOME) { Join-Path $env:CARGO_HOME "bin" } else { Join-Path $env:USERPROFILE ".cargo\bin" }
-          $candidatePaths = @(
-            (Join-Path $cargoBin "trip.exe"),
-            (Join-Path $cargoBin "trippy.exe"),
-            (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue),
-            (Get-Command trippy -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue)
-          )
-          $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
-
-          if ($trippyPath -and (Test-Path -Path $trippyPath)) {
-            echo "Trippy executable found at: $trippyPath"
-            echo "TRIPPY_PATH=$trippyPath" >> $env:GITHUB_ENV
-          } else {
-            Write-Error "Could not find trippy executable after cargo binstall. Checked: $($candidatePaths -join ', ')"
-            exit 1
-          }
-        shell: pwsh
-
       - name: Build release binary
         run: cargo build --release --target x86_64-pc-windows-msvc
         env:
@@ -417,20 +391,19 @@ jobs:
       - name: Create test build directory
         run: |
           mkdir -p pr-build
+          cp target/x86_64-pc-windows-msvc/release/mtr.exe pr-build/mtr.exe
           cp target/x86_64-pc-windows-msvc/release/mtr.exe pr-build/windows-mtr.exe
 
           # Copy documentation files individually to avoid PowerShell parameter issues
           cp README.md pr-build/
           cp LICENSE pr-build/
           if (Test-Path USAGE.md) { cp USAGE.md pr-build/ }
-
-          # Copy trippy executable
-          cp "${{ env.TRIPPY_PATH }}" pr-build/trip.exe
+          # Note: external trip.exe is not bundled. windows-mtr ships embedded Trippy runtime.
         shell: pwsh
 
       - name: Create ZIP package
         run: |
-          Compress-Archive -Path pr-build/* -DestinationPath pr-build/windows-mtr-PR${{ github.event.pull_request.number }}.zip -Force
+          Compress-Archive -Path pr-build/* -DestinationPath pr-build/windows-mtr-x86_64-pr${{ github.event.pull_request.number }}.zip -Force
         shell: pwsh
 
       - name: Upload PR build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-  # Trigger on immutable release version tags only
   push:
     tags:
       - 'v*.*.*'
@@ -23,174 +22,33 @@ jobs:
     name: Build and Test
     runs-on: windows-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
           targets: x86_64-pc-windows-msvc
 
-
-      # Use the more efficient Rust caching
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           save-if: ${{ startsWith(github.ref, 'refs/tags/') }}
           shared-key: "rust-windows-release"
           cache-bin: true
-          cache-directories: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git
-          cache-on-failure: true
 
-      # Fast check to catch errors early without full compilation
       - name: Check code
         run: cargo check --all-targets
-        env:
-          CARGO_INCREMENTAL: 0
 
-      - name: Install cargo-binstall
-        uses: taiki-e/install-action@6eb4471beed212309063862e6f5284ca3da3b01d # cargo-binstall
-
-      # Install trippy using prebuilt binaries first (same strategy as CI)
-      - name: Install trippy
-        run: |
-          echo "Installing trippy..."
-
-          # In CI, force installation to avoid stale "already installed" state
-          # and install only the expected Trippy binary (`trip`).
-          cargo binstall trippy --no-confirm --locked --force --bin trip
-
-          if ($LASTEXITCODE -ne 0) {
-            Write-Warning "cargo binstall could not fetch a prebuilt trippy binary; falling back to cargo install from source."
-            cargo install trippy --locked --force --bin trip
-            if ($LASTEXITCODE -ne 0) {
-              Write-Error "Failed to install trippy via both cargo binstall and cargo install fallback."
-              exit 1
-            }
-          }
-
-          $cargoBin = if ($env:CARGO_HOME) { Join-Path $env:CARGO_HOME "bin" } else { Join-Path $env:USERPROFILE ".cargo\bin" }
-          $candidatePaths = @(
-            (Join-Path $cargoBin "trip.exe"),
-            (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path -ErrorAction SilentlyContinue)
-          )
-          $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
-
-          if ($trippyPath -and (Test-Path -Path $trippyPath)) {
-            echo "Trippy executable found at: $trippyPath"
-            echo "TRIPPY_PATH=$trippyPath" >> $env:GITHUB_ENV
-          } else {
-            Write-Error "trippy executable was not found after install. Checked: $($candidatePaths -join ', ')"
-            exit 1
-          }
-        shell: pwsh
-        env:
-          CARGO_INCREMENTAL: 0
-
-      # Run the tests
       - name: Run tests
         run: cargo test --all
-        env:
-          CARGO_INCREMENTAL: 0
 
-      # Build the release binary with explicit binary name
       - name: Build release binary
         run: cargo build --release --bin mtr --target x86_64-pc-windows-msvc
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-C target-feature=+crt-static"
 
-      # Check build output and list files in target directory for debugging
-      - name: Check build output
-        run: |
-          echo "Checking for binary in target directories..."
-
-          # Check standard target directory
-          if (Test-Path "target/release") {
-            echo "Contents of target/release:"
-            Get-ChildItem -Path "target/release" -Filter "*.exe"
-          }
-
-          # Check target-specific directory
-          if (Test-Path "target/x86_64-pc-windows-msvc/release") {
-            echo "Contents of target/x86_64-pc-windows-msvc/release:"
-            Get-ChildItem -Path "target/x86_64-pc-windows-msvc/release" -Filter "*.exe"
-          }
-
-          # Also check with slashes in other direction
-          if (Test-Path "target\release") {
-            echo "Contents of target\release:"
-            Get-ChildItem -Path "target\release" -Filter "*.exe"
-          }
-
-          # Check target-specific directory with backslashes
-          if (Test-Path "target\x86_64-pc-windows-msvc\release") {
-            echo "Contents of target\x86_64-pc-windows-msvc\release:"
-            Get-ChildItem -Path "target\x86_64-pc-windows-msvc\release" -Filter "*.exe"
-          }
-        shell: pwsh
-
-      # New step: Verify the binary works correctly
       - name: Verify binary functionality
-        run: |
-          echo "Verifying binary functionality..."
-          $ErrorActionPreference = "Stop"
-          # Test help output
-          $helpOutput = & ./target/x86_64-pc-windows-msvc/release/mtr.exe --help
-          if (-not ($helpOutput -match "Usage:" -and $helpOutput -match "Arguments:" -and $helpOutput -match "Options:")) {
-            Write-Error "Help output verification failed"
-            exit 1
-          }
-          echo "✓ Help command verified"
-
-          # Test version output
-          $versionOutput = & ./target/x86_64-pc-windows-msvc/release/mtr.exe --version
-          if (-not ($versionOutput -match "mtr ")) {
-            Write-Error "Version output verification failed"
-            exit 1
-          }
-          echo "✓ Version command verified"
-
-          # Test basic command-line argument parsing (without network activity)
-          try {
-            Start-Process -FilePath "./target/x86_64-pc-windows-msvc/release/mtr.exe" -ArgumentList "-T", "-P", "443", "-c", "1", "-n", "--help" -NoNewWindow -Wait
-            echo "✓ Command-line argument parsing verified"
-          } catch {
-            Write-Error "Command-line argument parsing test failed: $_"
-            exit 1
-          }
-
-          echo "All binary verification tests passed successfully!"
         shell: pwsh
-
-      # Find and copy trippy executable for bundling
-      - name: Find trippy executable for bundling
-        id: find_trippy
         run: |
-          if (-not $env:TRIPPY_PATH -or -not (Test-Path $env:TRIPPY_PATH)) {
-            $cargoBin = if ($env:CARGO_HOME) { Join-Path $env:CARGO_HOME "bin" } else { Join-Path $env:USERPROFILE ".cargo\bin" }
-            $candidatePaths = @(
-              (Join-Path $cargoBin "trip.exe"),
-              (Get-Command trip -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Path -ErrorAction SilentlyContinue)
-            )
-            $trippyPath = $candidatePaths | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
-          } else {
-            $trippyPath = $env:TRIPPY_PATH
-          }
-
-          if ($trippyPath -and (Test-Path -Path $trippyPath)) {
-            echo "Found trippy at: $trippyPath"
-            echo "TRIPPY_PATH=$trippyPath" >> $env:GITHUB_ENV
-          } else {
-            Write-Error "Could not find trippy executable to bundle"
-            exit 1
-          }
-        shell: pwsh
-
+          ./target/x86_64-pc-windows-msvc/release/mtr.exe --help | Out-Null
+          ./target/x86_64-pc-windows-msvc/release/mtr.exe --version | Out-Null
 
   publish-package:
     name: Publish Container Packages
@@ -202,23 +60,18 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Log in to GHCR
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to Docker Hub
+      - name: Log in to Docker Hub (optional)
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -242,8 +95,7 @@ jobs:
             type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=semver,pattern={{version}},value=${{ github.ref_name }}
 
-      - name: Build and push image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: ./Dockerfile
@@ -256,206 +108,93 @@ jobs:
           provenance: true
           sbom: true
 
-  # Only run for tag pushes (real releases)
   release:
     name: Create Release
-    needs:
-      - build
-      - publish-package
+    needs: [build, publish-package]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: windows-latest
-    # Add explicit permissions for creating releases
     permissions:
-      contents: write  # Required for creating releases and uploading assets
+      contents: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
-          components: clippy
           targets: x86_64-pc-windows-msvc
 
+      - name: Build release binary
+        run: cargo build --release --bin mtr --target x86_64-pc-windows-msvc
 
-      # Use the more efficient Rust caching
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-        with:
-          save-if: ${{ startsWith(github.ref, 'refs/tags/') }}
-          shared-key: "rust-windows-release"
-          cache-bin: true
-          cache-directories: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git
-          cache-on-failure: true
-
-      # Create package directory structure and dist directory
-      - name: Create directories
-        run: |
-          mkdir -p dist
-          mkdir -p windows-mtr-official
+      - name: Assemble canonical release ZIP
         shell: pwsh
-
-      # Create a standalone executable ZIP
-      - name: Create official distribution package
         run: |
-          # Build the release binary explicitly first
-          cargo build --release --bin mtr --target x86_64-pc-windows-msvc
-
-          # Check for binary in different locations and list them for debugging
-          Write-Host "Searching for the MTR executable..."
-
-          $possiblePaths = @(
-            "target/x86_64-pc-windows-msvc/release/mtr.exe",
-            "target/release/mtr.exe",
-            "target\x86_64-pc-windows-msvc\release\mtr.exe",
-            "target\release\mtr.exe"
-          )
-
-          $mtrPath = $null
-          foreach ($path in $possiblePaths) {
-            if (Test-Path $path) {
-              Write-Host "Found MTR binary at: $path"
-              $mtrPath = $path
-              break
-            }
-          }
-
-          # If binary not found, look more broadly
-          if ($null -eq $mtrPath) {
-            Write-Host "Binary not found in expected paths, searching in target directories..."
-
-            # Look for any .exe files in target/release or target/x86_64-pc-windows-msvc/release
-            $exeFiles = @()
-            $exeFiles += Get-ChildItem -Path "target/release" -Filter "*.exe" -ErrorAction SilentlyContinue
-            $exeFiles += Get-ChildItem -Path "target/x86_64-pc-windows-msvc/release" -Filter "*.exe" -ErrorAction SilentlyContinue
-            $exeFiles += Get-ChildItem -Path "target\release" -Filter "*.exe" -ErrorAction SilentlyContinue
-            $exeFiles += Get-ChildItem -Path "target\x86_64-pc-windows-msvc\release" -Filter "*.exe" -ErrorAction SilentlyContinue
-
-            foreach ($file in $exeFiles) {
-              Write-Host "Found executable: $($file.FullName)"
-            }
-
-            # If we found any .exe files, use the first one
-            if ($exeFiles.Count -gt 0) {
-              $mtrPath = $exeFiles[0].FullName
-              Write-Host "Using: $mtrPath"
-            } else {
-              Write-Error "No MTR executable found after build"
-              exit 1
-            }
-          }
-
-          # Create directories
-          New-Item -ItemType Directory -Path 'dist' -Force
-          New-Item -ItemType Directory -Path 'windows-mtr-official' -Force
-
-          # Create direct executable asset and portable bundle payload
-          Copy-Item $mtrPath dist/windows-mtr-x86_64.exe
-          Copy-Item dist/windows-mtr-x86_64.exe windows-mtr-official/windows-mtr-x86_64.exe
-
-          # Add a simple README
+          New-Item -ItemType Directory -Force -Path dist,dist\bundle | Out-Null
+          Copy-Item target/x86_64-pc-windows-msvc/release/mtr.exe dist/bundle/mtr.exe
+          Copy-Item target/x86_64-pc-windows-msvc/release/mtr.exe dist/bundle/windows-mtr.exe
           @"
-          Windows MTR by Benji Shohet (benjisho)
-          -------------------------------------
+Windows MTR portable bundle
+===========================
 
-          This portable bundle contains:
-          - windows-mtr-x86_64.exe
+Run from an elevated PowerShell or Command Prompt for full probe support.
 
-          Quick Start:
-          1. Download the executable or this portable zip bundle.
-          2. Run Command Prompt or PowerShell as Administrator.
-          3. Run: mtr 8.8.8.8
+Quick start:
+.\mtr.exe 8.8.8.8
+.\windows-mtr.exe -r -c 10 8.8.8.8
 
-          For more information see: https://github.com/benjisho/windows-mtr
-          "@ > windows-mtr-official/README.txt
+Docs: https://github.com/benjisho/windows-mtr
+"@ | Set-Content dist/bundle/README.txt
 
-          # Create optional portable ZIP package
-          Compress-Archive -Path "windows-mtr-official\*" -DestinationPath "dist\windows-mtr-official-x86_64.zip" -Force
+          Compress-Archive -Path dist/bundle/* -DestinationPath dist/windows-mtr-x86_64.zip -Force
 
-          # Generate SHA256 checksums for all release assets
-          $exeHash = Get-FileHash -Path "dist\windows-mtr-x86_64.exe" -Algorithm SHA256
-          $zipHash = Get-FileHash -Path "dist\windows-mtr-official-x86_64.zip" -Algorithm SHA256
-          Set-Content -Path "dist\SHA256SUM" -Value @(
-            "$($exeHash.Hash)  windows-mtr-x86_64.exe",
-            "$($zipHash.Hash)  windows-mtr-official-x86_64.zip"
-          )
+          $zipHash = (Get-FileHash dist/windows-mtr-x86_64.zip -Algorithm SHA256).Hash.ToLower()
+          $exeHash = (Get-FileHash dist/bundle/mtr.exe -Algorithm SHA256).Hash.ToLower()
+          $aliasHash = (Get-FileHash dist/bundle/windows-mtr.exe -Algorithm SHA256).Hash.ToLower()
+          @(
+            "$zipHash  windows-mtr-x86_64.zip",
+            "$exeHash  mtr.exe",
+            "$aliasHash  windows-mtr.exe"
+          ) | Set-Content dist/bundle/SHA256SUM
+
+          Compress-Archive -Path dist/bundle/* -DestinationPath dist/windows-mtr-x86_64.zip -Force
+
+      - name: Validate release artifacts
         shell: pwsh
+        run: scripts/release/verify-release-artifacts.ps1 -ZipPath dist/windows-mtr-x86_64.zip -ShaPath dist/bundle/SHA256SUM
 
-      - name: Smoke check release asset names
+      - name: Release smoke tests from extracted ZIP
+        shell: pwsh
         run: |
-          $requiredAssets = @(
-            "dist/windows-mtr-x86_64.exe",
-            "dist/windows-mtr-official-x86_64.zip"
-          )
+          Expand-Archive dist/windows-mtr-x86_64.zip -DestinationPath dist/extracted -Force
+          dist/extracted/mtr.exe --help | Out-Null
+          dist/extracted/windows-mtr.exe --version | Out-Null
+          dist/extracted/mtr.exe -n -r -c 1 127.0.0.1 | Out-Null
 
-          foreach ($asset in $requiredAssets) {
-            if (-not (Test-Path $asset)) {
-              Write-Error "Missing required release asset: $asset"
-              exit 1
-            }
-          }
-
-          Write-Host "Release asset naming smoke check passed:"
-          Get-ChildItem dist | ForEach-Object { Write-Host " - $($_.Name)" }
-        shell: pwsh
-
-      # Upload all artifacts to GitHub
-      - name: Upload artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: windows-mtr-release
           path: |
-            dist/windows-mtr-x86_64.exe
-            dist/windows-mtr-official-x86_64.zip
-            dist/SHA256SUM
+            dist/windows-mtr-x86_64.zip
+            dist/bundle/SHA256SUM
           if-no-files-found: error
-          compression-level: 9
 
-      # Create the GitHub release with only the official zip file
       - name: Create GitHub Release
-        id: create_release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
-            dist/windows-mtr-x86_64.exe
-            dist/windows-mtr-official-x86_64.zip
-            dist/SHA256SUM
+            dist/windows-mtr-x86_64.zip
+            dist/bundle/SHA256SUM
           name: Windows MTR ${{ github.ref_name }}
           body: |
             # Windows MTR ${{ github.ref_name }}
 
-            A Windows-native clone of Linux MTR for network path diagnostics.
+            Canonical artifact source: GitHub Releases.
 
             ## Downloads
-
-            - [**windows-mtr-x86_64.exe**](https://github.com/benjisho/windows-mtr/releases/download/${{ github.ref_name }}/windows-mtr-x86_64.exe) - Direct executable
-            - [**windows-mtr-official-x86_64.zip**](https://github.com/benjisho/windows-mtr/releases/download/${{ github.ref_name }}/windows-mtr-official-x86_64.zip) - Official portable bundle
-            - [**SHA256SUM**](https://github.com/benjisho/windows-mtr/releases/download/${{ github.ref_name }}/SHA256SUM)
+            - windows-mtr-x86_64.zip
+            - SHA256SUM
 
             ## Quick Start
-
-            1. Download `windows-mtr-x86_64.exe` or `windows-mtr-official-x86_64.zip`.
-            2. Run Command Prompt or PowerShell as Administrator.
-            3. Run `mtr 8.8.8.8`.
-
-            ## Usage
-
-            ```
-            # Basic usage
-            windows-mtr 8.8.8.8
-
-            # TCP mode (for HTTPS)
-            windows-mtr -T -P 443 example.com
-
-            # Report mode (no live updates)
-            windows-mtr -r -c 10 google.com
-            ```
-
-            See [USAGE.md](https://github.com/benjisho/windows-mtr/blob/master/USAGE.md) for complete documentation.
-          draft: false
-          prerelease: false
+            1. Download and extract `windows-mtr-x86_64.zip`
+            2. Run `.\mtr.exe 8.8.8.8`
+            3. Or run `.\windows-mtr.exe -r -c 10 8.8.8.8`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,415 +1,90 @@
 # Windows MTR
 
-<div align="center">
-  <img src="assets/windows-mtr-upscaled.gif" alt="Windows MTR Banner" width="80%">
-  <h3>Enterprise-grade network diagnostics for Windows environments</h3>
+Windows-focused MTR-style network diagnostics CLI with embedded Trippy runtime.
 
-  <p align="center">
-    <a href="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml/badge.svg"></a>
-    <a href="https://github.com/benjisho/windows-mtr/actions/workflows/release.yml"><img alt="Release" src="https://github.com/benjisho/windows-mtr/actions/workflows/release.yml/badge.svg?branch=master"></a>
-    <a href="https://github.com/benjisho/windows-mtr/actions/workflows/security.yml"><img alt="Security" src="https://github.com/benjisho/windows-mtr/actions/workflows/security.yml/badge.svg"></a>
-    <a href="https://github.com/benjisho/windows-mtr/releases"><img alt="Version" src="https://img.shields.io/github/v/release/benjisho/windows-mtr?color=blue&label=Version"></a>
-    <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-orange.svg"></a>
-  </p>
+## Installation
 
-  <p align="center">
-    <a href="https://github.com/benjisho/windows-mtr/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/benjisho/windows-mtr?style=flat&label=Stars"></a>
-    <a href="USAGE.md"><img alt="Usage Guide" src="https://img.shields.io/badge/usage-guide-blue.svg"></a>
-    <a href="https://github.com/sponsors/benjisho"><img alt="Sponsor" src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=githubsponsors&logoColor=white"></a>
-  </p>
+> Canonical binary source: **GitHub Releases**.
 
-</div>
-
----
-
-Windows MTR is an enterprise-grade network diagnostics tool that brings the power of Linux's MTR utility to Windows environments with a focus on performance, security, and reliability. Built by Benji Shohet (benjisho) with enterprise-level best practices.
-
-## 📚 Table of Contents
-
-- [🌟 Features](#-features)
-- [📊 Performance](#-performance)
-- [🔐 Security](#-security)
-- [💻 Installation](#-installation)
-- [🚀 Quick Start](#-quick-start)
-- [📈 Advanced Features](#-advanced-features)
-- [📋 Documentation](#-documentation)
-- [📊 Project Status & Roadmap](#-project-status--roadmap)
-- [🤝 Contributing](#-contributing)
-- [📜 License](#-license)
-- [🙏 Acknowledgements](#-acknowledgements)
-
-## 🌟 Features
-
-<table>
-<tr>
-  <td width="33%">
-    <h3>🚀 Core Features</h3>
-    <ul>
-      <li>Multi-protocol support: ICMP, TCP SYN, and UDP</li>
-      <li>Interactive TUI for live monitoring</li>
-      <li>Report mode for static output generation</li>
-      <li>IPv4 and IPv6 support</li>
-      <li>Cross-platform compatibility</li>
-      <li>Simple, clean command-line interface</li>
-    </ul>
-  </td>
-  <td width="33%">
-    <h3>⚙️ Technical Excellence</h3>
-    <ul>
-      <li>RFC 4884 compliant implementation</li>
-      <li>Zero-copy, lock-free networking</li>
-      <li>State machine-based probe engine</li>
-      <li>Direct WinAPI integration</li>
-      <li>High-performance packet processing</li>
-      <li>ETW (Event Tracing for Windows) <em>(Roadmap)</em></li>
-    </ul>
-  </td>
-  <td width="33%">
-    <h3>🔍 Enterprise Benefits</h3>
-    <ul>
-      <li>Detailed performance metrics</li>
-      <li>Network path visualization</li>
-      <li>Early detection of routing issues</li>
-      <li>Packet loss identification</li>
-      <li>Latency measurement and analysis</li>
-      <li>Automated release and testing</li>
-    </ul>
-  </td>
-</tr>
-</table>
-
-## 📊 Performance
-
-Our benchmarks demonstrate Windows MTR's commitment to high-performance networking:
-
-- **50+ million** packets per second processing capability
-- **87.3%** function coverage with automated testing
-- **Sub-microsecond** timing precision for accurate measurements
-- **40%** smaller distribution size with XZ compression
-
-## 🔐 Security
-
-Windows MTR is built with enterprise-level security practices:
-
-- 🛡️ Regular security audits with automated scanning
-- 🔒 All dependencies vetted for vulnerabilities
-- 🧪 Fuzz harness implemented; CI integration in progress
-- 🔑 Cryptographically signed releases with SHA-256 verification
-
-### REST API security and operational limits (v1, implemented)
-
-For REST API mode (`mtr --api`), the enforced security baseline is:
-
-- Default bind address: `127.0.0.1:3000` (localhost only, enforced)
-- Non-local bind requires explicit auth strategy (`--api-auth api-key|mtls`) and secure key handling (`--api-key-env` preferred for `api-key`)
-- Default request timeout: `10s`
-- Max concurrent probes: `8`
-- Max requests per rate-limit window: `8`
-- Rate-limit window duration: `10s`
-- Max targets per request: `8`
-- Max payload size: `16 KiB`
-- Max retained completed jobs: `1024`
-- Completed job TTL: `15m`
-
-See [docs/security/rest-api.md](docs/security/rest-api.md) for the full threat model and controls.
-
-## 💻 Installation
-
-> [!TIP]
-> For most users, the best path is: **GitHub Releases → MSI installer → Run as Administrator**.
-
-### Windows
-
-#### Professional Installation (Recommended)
-
-1. Download the latest `windows-mtr-1.0.0-x86_64-pc-windows-msvc.msi` from [GitHub Releases](https://github.com/benjisho/windows-mtr/releases)
-2. Run the installer and follow the installation wizard
-3. Find Windows MTR in your Start Menu or run `mtr` from any command prompt
-
-#### Portable Installation
-
-1. Download `windows-mtr-x86_64.exe` (direct executable) or `windows-mtr-official-x86_64.zip` (official portable bundle) from [GitHub Releases](https://github.com/benjisho/windows-mtr/releases)
-2. Extract the ZIP file if you chose the portable bundle
-3. Run the downloaded executable directly (for example `windows-mtr-x86_64.exe 8.8.8.8`) or rename it to `mtr.exe` for shorter commands
-
-#### System Requirements
-
-- Windows 7/Server 2012 R2 or later
-- 50MB disk space
-- Administrator privileges required for network operations
-
-### Docker
-
-```bash
-# Pull a release-tagged Windows MTR container (GHCR)
-docker pull ghcr.io/benjisho/windows-mtr:v1.0.0
-
-# Pull a release-tagged Windows MTR container (Docker Hub)
-docker pull benjisho/windows-mtr:v1.0.0
-
-# Run with direct networking (pin to a specific release tag)
-docker run --network host ghcr.io/benjisho/windows-mtr:v1.0.0 -c 5 -r 8.8.8.8
-```
-
-Container images are published from the `Release` workflow to both GHCR (`ghcr.io/benjisho/windows-mtr`) and Docker Hub (`benjisho/windows-mtr`) from explicit release tags like `v1.2.3` for `linux/amd64` and `linux/arm64`.
-
-> [!NOTE]
-> Windows container networking can vary by environment. If `--network host` is not available in your setup, run the binary directly on the host for full probe capability.
-
-### Build from Source on Windows
-
-Follow these steps to compile the Windows MTR executable:
-
-1. Install [Rust](https://www.rust-lang.org/tools/install) with **rustup** (Rust **1.88.0+** required).
-2. Install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) and select the **Desktop development with C++** workload.
-3. Clone this repository and change into the project directory:
-
-   ```bash
-   git clone https://github.com/benjisho/windows-mtr.git
-   cd windows-mtr
-   ```
-
-4. *(Optional)* Generate a lockfile if you need to build offline:
-
-   ```bash
-   cargo generate-lockfile
-   ```
-
-5. Compile in release mode:
-
-   ```bash
-   cargo build --release
-   ```
-
-6. After a successful build the binary is located at `target\release\mtr.exe`.
-
-The resulting executable is now **self-contained** and embeds Trippy directly (no additional runtime executable required).
-
-## 🚀 Quick Start
-
-### Administrator Privileges Required
-
-Windows MTR requires administrator privileges to run properly, as it needs to send and receive network packets at a low level:
-
-1. Right-click on Command Prompt or PowerShell and select "Run as administrator"
-2. Navigate to your Windows MTR directory or add it to your PATH
-3. Run your MTR commands with elevated privileges
-
-### Basic ICMP Trace (Default)
-
-```bash
-mtr 8.8.8.8
-```
-
-> [!TIP]
-> If you downloaded a standalone `.exe` and did not install via MSI, use that filename directly (for example `windows-mtr-x86_64.exe 8.8.8.8`) unless you renamed it to `mtr.exe`.
-
-### Native Ratatui UI (live hops + table + charts)
-
-```bash
-mtr --ui native 8.8.8.8
-```
-
-### Report mode with DNS disabled (faster + script-friendly)
-
-```bash
-mtr -n -r -c 20 1.1.1.1
-```
-
-### Generate a Shareable Report
-
-```bash
-mtr -c 10 -r 8.8.8.8 > network-report.txt
-```
-
-### Generate JSON for automation
-
-```bash
-mtr --json -c 20 8.8.8.8 > network-report.json
-```
-
-### Test HTTPS Connectivity
-
-```bash
-mtr -T -P 443 example.com
-```
-
-### REST API mode (same binary)
-
-```bash
-# Start API server on localhost (default 127.0.0.1:3000)
-mtr --api
-
-# Start API server on a specific localhost bind
-mtr --api --api-bind 127.0.0.1:4000
-
-# Secure remote bind with API key from environment (preferred)
-WINDOWS_MTR_API_KEY='replace-me' mtr --api --api-bind 0.0.0.0:4000 --api-auth api-key --api-key-env WINDOWS_MTR_API_KEY
-
-# Tune REST API rate limiting (defaults: 8 requests per 10-second window)
-mtr --api --api-max-requests-per-window 20 --api-rate-limit-window-seconds 30
-
-# Secure remote bind with mTLS identity forwarding
-mtr --api --api-bind 0.0.0.0:4000 --api-auth mtls
-```
-
-### Full Usage Examples
-
-Visit our [detailed usage guide](USAGE.md) for comprehensive examples.
-
-## 📈 Advanced Features
-
-<details>
-<summary><b>Network Troubleshooting Playbook</b></summary>
-
-### Diagnosing High Latency
-
-When experiencing high latency to a destination, use:
-
-```bash
-mtr -c 50 -i 0.2 destination
-```
-
-This sends 50 packets with a short interval of 0.2 seconds to help identify where latency spikes occur.
-
-### Identifying Packet Loss
-
-To accurately measure packet loss along a route:
-
-```bash
-mtr -c 100 -r destination
-```
-
-The report mode with a higher count provides more statistically significant packet loss data.
-
-### Testing Specific Services
-
-For web server connectivity issues:
-
-```bash
-mtr -T -P 80 webserver.example.com
-```
-
-For HTTPS:
-
-```bash
-mtr -T -P 443 webserver.example.com
-```
-
-For email server connectivity:
-
-```bash
-mtr -T -P 25 mailserver.example.com
-```
-
-</details>
-
-<details>
-<summary><b>Enterprise Integration</b></summary>
-
-### API Usage
-
-Windows MTR can be integrated into your monitoring systems:
-
-```bash
-mtr -c 10 -r --json 8.8.8.8 > metrics.json
-```
-
-### Automation
-
-Schedule regular network tests with Windows Task Scheduler:
+Download `windows-mtr-x86_64.zip` from [GitHub Releases](https://github.com/benjisho/windows-mtr/releases), extract it, then run:
 
 ```powershell
-$action = New-ScheduledTaskAction -Execute "C:\Program Files\Windows-MTR\mtr.exe" -Argument "-c 10 -r 8.8.8.8 -o output.txt"
-$trigger = New-ScheduledTaskTrigger -Daily -At 8am
-Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "Daily Network Test" -Description "Runs MTR test each morning"
+.\mtr.exe 8.8.8.8
+.\windows-mtr.exe -r -c 10 8.8.8.8
 ```
 
-### Centralized Monitoring
+The ZIP contains exactly:
+- `mtr.exe`
+- `windows-mtr.exe`
+- `README.txt`
+- `SHA256SUM`
 
-For enterprise environments, use our logging features to send results to central systems:
+### Distribution matrix
 
-```bash
-mtr --reporter json --log-level info 8.8.8.8 | curl -X POST -d @- https://logging.example.com/api/v1/logs
+| Method | Status | Command |
+|---|---|---|
+| GitHub Releases | supported (canonical) | Download ZIP, extract, run `.\mtr.exe` |
+| WinGet | planned (manifest prepared) | `winget install --manifest .\packaging\winget` |
+| Scoop | planned (manifest prepared) | `scoop install .\packaging\scoop\windows-mtr.json` |
+| Chocolatey | planned (template prepared) | `choco pack` then local test install |
+| crates.io | future | `cargo install windows-mtr --locked` |
+| cargo-binstall | future | deferred until release naming is stable |
+| Docker/GHCR | partial / optional | `docker run --rm ghcr.io/benjisho/windows-mtr:latest --help` |
+| Homebrew / Snap / .deb / .rpm | deferred | pending Linux/macOS runtime validation |
+
+See [docs/distribution.md](docs/distribution.md) for maintainer details.
+
+## UI modes
+
+- `--ui default`: embedded Trippy interactive TUI.
+- `--ui enhanced`: embedded Trippy TUI + windows-mtr diagnostic thresholds/overlays.
+- `--ui dashboard`: **experimental** windows-mtr dashboard that polls JSON snapshots; useful if embedded Trippy TUI crashes in your terminal.
+- `--ui native`: deprecated compatibility alias for `--ui dashboard`.
+
+## Quick start
+
+```powershell
+# interactive default TUI
+mtr 8.8.8.8
+
+# enhanced interactive TUI
+mtr --ui enhanced 8.8.8.8
+
+# dashboard fallback mode
+mtr --ui dashboard 8.8.8.8
+
+# stable report mode
+mtr -n -r -c 5 8.8.8.8
 ```
 
-</details>
+### Troubleshooting
 
-## 📋 Documentation
+If interactive TUI crashes or exits with `0xC0000005`, try:
 
-- [📚 Full Documentation Hub](docs/README.md)
-- [🛣️ Product Roadmap](docs/ROADMAP.md)
-- [🧩 CLI/API Reference](docs/API.md)
-- [🧪 Probe parity matrix](docs/probe-parity.md)
-- [📑 Usage Examples](docs/USAGE.md)
-- [🛠️ Development Setup](DEVELOPMENT.md)
-- [🤝 Contributing Guide](CONTRIBUTING.md)
-- [🔄 Changelog](CHANGELOG.md)
-
-## 📊 Project Status & Roadmap
-
-The full roadmap now lives in [docs/ROADMAP.md](docs/ROADMAP.md), which is the single source of truth for feature status and planned milestones.
-
-Quick snapshot:
-
-- ✅ Released: Core MTR functionality, MSI installer, IPv6, Docker, JSON output, DNS cache TTL, REST API v1 (authentication, rate limiting, concurrency controls).
-- 🚧 In progress: Native Ratatui UI (experimental preview via `--ui native`), security hardening gates (`cargo-audit` in CI, fuzz harness pending CI integration).
-- 📅 Planned / 🛣️ Roadmap: SNMP integration, ETW observability, versioned JSON schema + CSV export, runtime cleanup.
-
-## 🤝 Contributing
-
-We welcome contributions from the community! Check out our [contributing guidelines](CONTRIBUTING.md) to get started.
-
-### Run repository checks locally (manual)
-
-To run the same repository-wide hook suite used in CI:
-
-```bash
-python -m pip install pre-commit
-pre-commit run --all-files
+```powershell
+.\mtr.exe --ui dashboard 8.8.8.8
 ```
 
-Before running local pre-commit hooks, install Rust via [rustup](https://www.rust-lang.org/tools/install) and make sure `cargo` is available on your `PATH`.
+For stable diagnostics in automation/scripts:
 
-### Local API verification workflow
-
-To validate API behavior and schema compatibility locally, run:
-
-```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --test api_contract_tests -- --nocapture
-cargo test --test api_integration_tests -- --nocapture
-./scripts/check_openapi_compat.sh master
+```powershell
+.\mtr.exe -n -r -c 5 8.8.8.8
 ```
 
-`check_openapi_compat.sh` resolves `origin/<base-ref>` first, then local `<base-ref>`, then `HEAD~1` as a local fallback. It requires a local Docker engine and you can pin a different `oasdiff` image via `OASDIFF_IMAGE=<image:tag>`.
+## Capability status
 
-For any workflow change, pin each GitHub Actions `uses:` reference to a full 40-character commit SHA (avoid mutable tags/branches).
+Strategic capability claims are validated in:
+- [docs/capability-validation.md](docs/capability-validation.md)
 
-## 📜 License
+Use that matrix as source-of-truth for what is **Full**, **Strong**, **Partial**, **Basic**, **Not implemented**, or **Roadmap only**.
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+## Docs
 
-## 📊 Analytics & Usage Metrics
+- [USAGE.md](USAGE.md)
+- [docs/distribution.md](docs/distribution.md)
+- [docs/capability-validation.md](docs/capability-validation.md)
+- [docs/security/rest-api.md](docs/security/rest-api.md)
 
-<div align="center">
-  <img src="https://img.shields.io/badge/Code%20Coverage-87.3%25-brightgreen" alt="Code Coverage" />
-  <img src="https://img.shields.io/badge/Test%20Cases-35%2B-blue" alt="Test Cases" />
-  <img src="https://img.shields.io/badge/Integration%20Tests-10%2B-blue" alt="Integration Tests" />
-  <img src="https://img.shields.io/badge/Fuzz%20Tests-1000%2B-blue" alt="Fuzz Tests" />
-</div>
+## License
 
-## 🙏 Acknowledgements
-
-- [trippy](https://github.com/fujiapple852/trippy) - Provides core networking functionality
-- [ratatui](https://github.com/ratatui-org/ratatui) - Powers our beautiful terminal interface
-- Our amazing [contributors](https://github.com/benjisho/windows-mtr/graphs/contributors) who help improve Windows MTR
-
----
-
-<div align="center">
-  <sub>Built with ❤️ by <a href="https://github.com/benjisho">Benji Shohet</a> and the Windows MTR Team</sub>
-  <br/>
-  <sub>© 2025 Windows MTR Project. All Rights Reserved.</sub>
-</div>
+Apache-2.0. See [LICENSE](LICENSE).

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,193 +1,66 @@
 # Windows MTR Usage Guide
 
-## Basic Usage
+## Basic usage
 
 ```bash
 mtr [options] <hostname-or-ip>
 ```
 
-> On Windows portable downloads, replace `mtr` with your actual executable name (for example `windows-mtr-x86_64.exe`).
+On portable ZIP installs, run `mtr.exe` or `windows-mtr.exe` from the extracted folder.
 
-## Core Options
+## UI modes
+
+| Mode | Command | Notes |
+|---|---|---|
+| default | `mtr 8.8.8.8` | Embedded Trippy TUI (primary interactive mode). |
+| enhanced | `mtr --ui enhanced 8.8.8.8` | Embedded Trippy TUI plus threshold-based overlays. |
+| dashboard | `mtr --ui dashboard 8.8.8.8` | Experimental windows-mtr dashboard that polls JSON snapshots; fallback if embedded TUI crashes. |
+| native (alias) | `mtr --ui native 8.8.8.8` | Deprecated compatibility alias for `dashboard`. |
+
+## Common options
 
 | Option | Description |
 |---|---|
-| `<hostname-or-ip>` | Target host to trace (required) |
 | `-T` | TCP SYN probes |
 | `-U` | UDP probes |
-| `-P, --port <PORT>` | Target port for TCP/UDP (`-T`/`-U`) |
-| `--source-port <PORT>` | Source port for TCP/UDP |
-| `-S, --src <IP>` | Source IP address |
+| `-P, --port <PORT>` | Target port for TCP/UDP |
+| `--source-port <PORT>` | Source port |
+| `-S, --src <IP>` | Source IP |
 | `--interface <NAME>` | Source interface |
-| `-m <HOPS>` | Max TTL/hops |
-| `-s, --packet-size <BYTES>` | Probe packet size |
+| `-m <HOPS>` | Max hops |
+| `-s, --packet-size <BYTES>` | Packet size |
+| `-r` | Report mode |
+| `-w, --report-wide` | Wide report output |
+| `-j, --json` | JSON output |
+| `--json-pretty` | Pretty JSON output |
+| `-c <COUNT>` | Report cycles |
+| `-n` | Disable reverse DNS |
+| `-b, --show-asn` | ASN rendering |
+| `-z` | DNS/ASN lookup shortcut |
+| `--ecmp <classic\|paris\|dublin>` | Multipath strategy |
+| `--trippy-flags "<FLAGS>"` | Advanced passthrough flags |
 
-## Output & Report Options
+## Troubleshooting
 
-| Option | Description |
-|---|---|
-| `-r` | One-shot report mode (pretty table) |
-| `-w, --report-wide` | Wide report output mode |
-| `-j, --json` | JSON report mode |
-| `--json-pretty` | Pretty JSON report mode |
-| `-c <COUNT>` | Probe/report cycles |
-| `-n` | Disable reverse DNS rendering (show IP only) |
-| `-b, --show-asn` | Enable ASN lookup/rendering |
-| `-z` | DNS ASN lookup shortcut |
-| `--ui <default\|enhanced\|native>` | Interactive UI preset (enhanced enables diagnostic overlays) |
+If embedded interactive TUI fails with `0xC0000005`:
 
-## Native Ratatui UI
-
-Use `--ui native` to run the built-in Ratatui interface with live hop data, a hop table, and charts.
-
-```bash
-mtr --ui native 8.8.8.8
+```powershell
+.\mtr.exe --ui dashboard 8.8.8.8
 ```
 
-Controls:
-- `Tab` / `→` switch to next tab
-- `←` switch to previous tab
-- `q` quit
+For stable non-interactive diagnostics:
 
-When probe snapshots fail repeatedly, the help footer surfaces the latest poll error and live troubleshooting hints (run with Administrator privileges, review firewall policy, or try report mode with `-r`). If no hop data is detected for 15 seconds, the footer also prompts you to quit (`q`) and retry in report mode for immediate diagnostics.
-
-`--ui native` accepts the standard probe and output tuning options, and renders them in the native Ratatui view.
-
-## Enhanced UI options
-
-The `enhanced` preset applies defaults tuned for quicker incident triage:
-
-- Latency color bands: `--latency-warn-ms 100`, `--latency-bad-ms 250`
-- Loss color bands: `--loss-warn-pct 2`, `--loss-bad-pct 5`
-- Row coloring: `--enhanced-row-color on`
-- Per-hop trend/sparkline column: `--enhanced-sparklines on`
-- Percentile + jitter summary area: `--enhanced-summary on`
-
-| Option | Description |
-|---|---|
-| `--latency-warn-ms <MS>` | Warning threshold for per-hop latency coloring |
-| `--latency-bad-ms <MS>` | Critical threshold for per-hop latency coloring |
-| `--loss-warn-pct <PCT>` | Warning threshold for packet loss coloring |
-| `--loss-bad-pct <PCT>` | Critical threshold for packet loss coloring |
-| `--enhanced-row-color <on\|off>` | Enable/disable row band coloring in enhanced mode |
-| `--enhanced-sparklines <on\|off>` | Enable/disable per-hop trend/sparkline column |
-| `--enhanced-summary <on\|off>` | Enable/disable percentile and jitter summary area |
-
-## Timing & DNS Cache
-
-| Option | Description |
-|---|---|
-| `-i <SECONDS>` | Minimum round duration |
-| `-W, --timeout <SECONDS>` | Probe grace timeout |
-| `--dns-cache-ttl <SECONDS>` | Per-run DNS cache TTL |
-
-## Power User Passthrough
-
-| Option | Description |
-|---|---|
-| `--trippy-flags "<FLAGS>"` | Forwards native Trippy flags verbatim |
-| `--ecmp <classic\|paris\|dublin>` | ECMP/multipath strategy |
-
-## Linux `mtr` parity mapping (minimum viable)
-
-| Linux mtr | windows-mtr | trippy |
-|---|---|---|
-| `-b` | `-b`, `--show-asn` | `--dns-lookup-as-info` |
-| `-s` | `-s`, `--packet-size` | `--packet-size` |
-| `-S` (source IP) | `-S`, `--src` | `--source-address` |
-| `-z` | `-z` | `--dns-lookup-as-info` |
-| `--ecmp` | `--ecmp` | `--multipath-strategy` |
-| `-w` (report wide) | `-w`, `--report-wide` | `--mode pretty` |
-| `-n` | `-n` | `--tui-address-mode ip` |
-| `-c` | `-c` | `--report-cycles`, `--max-rounds` |
-| `-i` | `-i` | `--min-round-duration` |
-| `-W` | `-W`, `--timeout` | `--grace-duration` |
-| `-m` | `-m` | `--max-ttl` |
-
-## Examples
-
-```bash
-# Interactive TUI
-mtr 8.8.8.8
-
-# Interactive TUI (enhanced diagnostic preset)
-mtr --ui enhanced 8.8.8.8
-
-# Enhanced mode with custom threshold bands + toggles
-mtr --ui enhanced --latency-warn-ms 80 --latency-bad-ms 180 --loss-warn-pct 1 --loss-bad-pct 3 --enhanced-sparklines off 8.8.8.8
-
-# TCP report
-mtr -T -P 443 -c 15 -r github.com
-
-# JSON output for automation
-mtr --json -c 20 1.1.1.1
-
-# Force source IP + packet size
-mtr -S 192.0.2.10 -s 128 8.8.4.4
-
-# Advanced trippy tuning passthrough
-mtr --trippy-flags "--log-format json --verbose --tui-refresh-rate 150ms" 8.8.8.8
+```powershell
+.\mtr.exe -n -r -c 5 8.8.8.8
 ```
 
-## Default vs enhanced mode (side-by-side)
-
-| Default mode | Enhanced mode |
-|---|---|
-| `mtr 8.8.8.8` | `mtr --ui enhanced 8.8.8.8` |
-| Standard hop table | Adds threshold-based row coloring |
-| Average-focused quick view | Adds percentile + jitter summary |
-| No explicit trend column | Optional per-hop sparkline trend column |
-
-![Default mode demo](assets/windows-mtr-m.gif)
-![Enhanced mode demo](assets/windows-mtr-upscaled.gif)
-
-## REST API startup and operational limits (v1, implemented)
-
-Use API mode from the main binary and keep these defaults unless you have a reviewed reason to change them:
+## REST API mode (implemented, validate before production)
 
 ```bash
-# Start API server on default localhost bind
 mtr --api
-
-# Override bind address on localhost
 mtr --api --api-bind 127.0.0.1:4000
-
-# Secure remote bind with API key from environment (preferred)
 WINDOWS_MTR_API_KEY='replace-me' mtr --api --api-bind 0.0.0.0:4000 --api-auth api-key --api-key-env WINDOWS_MTR_API_KEY
-
-# Tune REST API request rate limiting
-mtr --api --api-max-requests-per-window 20 --api-rate-limit-window-seconds 30
-
-# Tune REST API completed-job retention controls
-mtr --api --api-max-completed-jobs 512 --api-completed-job-ttl-seconds 1200
-
-# Secure remote bind with mTLS
 mtr --api --api-bind 0.0.0.0:4000 --api-auth mtls
-
-# mTLS ingress trust list (header-based mode) for non-loopback trusted reverse proxy hops
-mtr --api --api-bind 0.0.0.0:4000 --api-auth mtls --api-mtls-trusted-ingress 10.0.0.10
 ```
 
-- Bind to `127.0.0.1:3000` by default
-- Require explicit opt-in for non-local bind addresses
-- Request timeout: `10s`
-- Max concurrent probes: `8`
-- Max requests per rate-limit window: `8`
-- Rate-limit window duration: `10s`
-- Max targets per request: `8`
-- Max request body size: `16 KiB`
-- Max retained completed jobs: `1024`
-- Completed job TTL: `15m`
-
-Authentication enforcement in v1:
-- Local-only bind: `none-local-only` is acceptable
-- Non-local bind: require explicit `--api-auth api-key|mtls`
-- For `api-key`, prefer `--api-key-env <ENV_VAR>` over inline `--api-key` to avoid exposing secrets in shell history
-- For `mtls` header mode, trusted ingress IP sources are configurable via repeatable `--api-mtls-trusted-ingress <IP>`
-
-Input validation before probe execution:
-- Hostnames/IPs normalized and validated
-- Ports validated in `1..=65535` (required for TCP/UDP)
-- Intervals/timeouts validated as positive finite numbers (`timeout >= interval`)
-
-See [docs/security/rest-api.md](docs/security/rest-api.md).
+See [docs/security/rest-api.md](docs/security/rest-api.md) and [docs/capability-validation.md](docs/capability-validation.md) for current validation status.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,100 +1,24 @@
-# Installation Guide
+# Installation
 
-This guide covers recommended installation methods for Windows MTR.
+## Primary supported path: GitHub Releases
 
-## Table of Contents
-
-- [System Requirements](#system-requirements)
-- [Install from GitHub Releases](#install-from-github-releases)
-- [Portable Installation](#portable-installation)
-- [Build from Source](#build-from-source)
-- [Verification](#verification)
-- [Uninstall](#uninstall)
-- [Troubleshooting](#troubleshooting)
-
-## System Requirements
-
-- Windows 7 / Server 2012 R2 or later (recommended: modern supported Windows versions)
-- Administrator privileges for full probe capabilities
-- ~50 MB free disk space for binaries and dependencies
-
-## Install from GitHub Releases
-
-Recommended for most users.
-
-1. Open the [latest release page](https://github.com/benjisho/windows-mtr/releases).
-2. Download the MSI package for your architecture.
-3. Run installer as Administrator.
-4. Verify from terminal:
+1. Download `windows-mtr-x86_64.zip` from the project releases page.
+2. Verify checksum with `SHA256SUM`.
+3. Extract and run one of:
 
 ```powershell
-mtr --help
+.\mtr.exe 8.8.8.8
+.\windows-mtr.exe -r -c 10 8.8.8.8
 ```
 
-## Portable Installation
+## Package manager readiness (not yet published)
 
-1. Download `windows-mtr-x86_64.exe` (direct executable) or `windows-mtr-official-x86_64.zip` (official portable bundle).
-2. Extract to a folder (if using ZIP), e.g. `C:\Tools\windows-mtr`.
-3. Run directly:
+- WinGet: template manifests prepared in `packaging/winget/`
+- Scoop: template manifest prepared in `packaging/scoop/windows-mtr.json`
+- Chocolatey: portable template prepared in `packaging/chocolatey/`
 
-```powershell
-.\mtr.exe --help
-```
+All packaging channels should reference the same GitHub Release ZIP.
 
-Optional: add folder to `PATH`.
-
-## Build from Source
-
-### Prerequisites
-
-- Rust (1.88.0+)
-- Visual Studio Build Tools (Desktop development with C++)
-
-### Build steps
-
-```bash
-git clone https://github.com/benjisho/windows-mtr.git
-cd windows-mtr
-cargo build --release
-```
-
-Binary output:
-
-- `target\release\mtr.exe`
-
-## Verification
-
-Run a quick report test:
-
-```powershell
-mtr -r -c 5 8.8.8.8
-```
-
-JSON verification:
-
-```powershell
-mtr --json -c 5 1.1.1.1
-```
-
-## Uninstall
-
-- MSI install: remove via **Apps & Features**.
-- Portable install: delete extracted folder and any PATH entry.
-
-## Troubleshooting
-
-### Command not found
-
-- Restart terminal after modifying PATH.
-- Use full path to `mtr.exe` to verify binary is valid.
-
-### Insufficient privileges
-
-- Launch terminal as Administrator and rerun command.
-
-### Endpoint filtering blocks probes
-
-- Validate local firewall/network security policy.
-- Try different protocol mode (`-T` or `-U`) for diagnostics.
-
-For operational usage details, see [USAGE.md](USAGE.md).
+For status, see:
+- [docs/distribution.md](distribution.md)
+- [docs/capability-validation.md](capability-validation.md)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,7 +27,7 @@ For release-by-release details, see the [changelog](../CHANGELOG.md).
 | Container publishing to GHCR + Docker Hub | ✅ Released | v1.2.x |
 | REST API (API key + mTLS auth, rate limiting, concurrency controls) | ✅ Released | v1.1.3 |
 | SNMP Integration | 📅 Planned | H2 2026 |
-| Native Ratatui UI (tabs, hop table, charts) | 🚧 In Progress (Experimental Preview via `--ui native`) | H2 2026 |
+| Dashboard UI (tabs, hop table, charts) | 🚧 In Progress (Experimental Preview via `--ui dashboard (native alias deprecated)`) | H2 2026 |
 | ETW + Windows observability integrations | 🛣️ Roadmap | H2 2026 |
 | Versioned JSON schema + CSV export | 🛣️ Roadmap | H2 2026 |
 | Security hardening gates (cargo-audit + fuzz harness in CI) | 🚧 In Progress (cargo-audit live, fuzz harness pending) | H2 2026 |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,8 +19,8 @@ This document serves as the single source of truth for feature delivery status.
 - **Status**: ✅ Released in v1.1.3  
 - **Notes**: Implemented with API key and mTLS authentication, rate limiting, and concurrency controls. Default bind is localhost-only (`127.0.0.1:3000`). See [REST API Documentation](security/rest-api.md) for the full threat model and usage examples.
 
-## Native Ratatui UI
-- **Status**: 🚧 In Progress (Experimental Preview via `--ui native`)  
+## Dashboard UI
+- **Status**: 🚧 In Progress (Experimental Preview via `--ui dashboard (native alias deprecated)`)  
 - **Notes**: Preview available on `master`. Provides live hop table, latency/loss charts, and multi-tab interface. Not yet promoted to a stable release; expect rough edges.
 
 ## ETW/Windows Observability Integration

--- a/docs/capability-validation.md
+++ b/docs/capability-validation.md
@@ -1,0 +1,52 @@
+# Capability validation matrix
+
+Validation date: 2026-04-26.
+
+Status scale used:
+- Full
+- Strong
+- Partial
+- Basic
+- Not implemented
+- Roadmap only
+
+A capability is only marked **Full** if implemented, tested, documented, and validated from release artifact or documented runtime path.
+
+| Capability | Claimed status | Evidence in code | Evidence in tests | Evidence in CI | Evidence in release artifact | Evidence in docs | Final validated status | Notes / required follow-up |
+|---|---|---|---|---|---|---|---|---|
+| ICMP probes | strong | probe request/build pipeline in `src/service/mod.rs` | unit/probe tests | `cargo test --all` in CI/release | release smoke command uses local report | README/USAGE examples | Strong | Needs explicit artifact-level multi-hop validation. |
+| TCP probes | strong | `-T` + `--target-port` mapping | CLI/unit tests | CI test suite | not run in release smoke | docs examples | Partial | Add release smoke test for TCP mode. |
+| UDP probes | strong | `-U` mapping | CLI/unit tests | CI test suite | not run in release smoke | docs examples | Partial | Add release smoke test for UDP mode. |
+| IPv6 | claimed | parser accepts host/IP | no explicit IPv6 artifact test found | not explicit | none | docs mention parity | Basic | Needs validated runtime tests in CI/release. |
+| ECMP / multipath | claimed | `--ecmp` -> `--multipath-strategy` | unit mapping tests | CI tests | none | usage docs | Partial | No release-artifact validation yet. |
+| custom packet size | claimed | `--packet-size` mapping | unit mapping tests | CI tests | none | usage docs | Partial | Add artifact smoke with `-s`. |
+| source IP / interface | claimed | `--src` / `--interface` mapping | unit mapping tests | CI tests | none | usage docs | Partial | Needs privileged artifact-path testing. |
+| interactive TUI | strong | embedded trippy launch path in `src/main.rs` | CLI/tests | CI help/version checks | release smoke `--help` only | docs | Strong | Runtime depends on terminal/privileges. |
+| dashboard UI | experimental | `src/native_ui.rs` + JSON snapshot args builder | unit tests + fixture | CI test suite | not full interactive in release workflow | README/USAGE | Partial | Non-interactive parser/snapshot tested; interactive stability varies. |
+| report mode | strong | `--mode pretty` plan logic | tests/report tests | CI tests | release smoke runs `-n -r -c 1 127.0.0.1` | docs | Strong | Good baseline coverage. |
+| JSON output | strong | `--json` / pretty flow | tests | CI tests | dashboard consumes json snapshots | docs | Strong | Add explicit release artifact JSON smoke later. |
+| CSV / wide output | mixed | wide mode mapped; CSV not seen | report tests for wide | CI tests | not in artifact tests | docs mention wide | Basic | CSV appears not implemented; keep wording cautious. |
+| REST API | implemented | `src/service/rest_api.rs`, `rest_server.rs` | API integration/security tests | CI `cargo test --all` | not exercised from release zip | docs/security + API docs | Partial | Strong code/tests but no release-path validation yet. |
+| OpenAPI spec | implemented | `docs/api/openapi.yaml` | api contract tests | CI tests include contract checks | not artifact-level | docs/api | Partial | Keep as available for testing. |
+| API key auth | implemented | auth strategy config | security tests | CI tests | not artifact-level | security docs | Partial | Needs deployment validation guidance. |
+| mTLS auth | implemented | auth strategy config | security tests | CI tests | not artifact-level | security docs | Partial | Header-forwarding trust model documented. |
+| rate limiting | implemented | API config defaults/enforcement | rest security tests | CI tests | not artifact-level | docs/security | Partial | Add e2e API runtime smoke in release path. |
+| concurrency limiting | implemented | API config controls | tests | CI tests | not artifact-level | docs/security | Partial | Same as above. |
+| payload limiting | implemented | API request size controls | tests | CI tests | not artifact-level | docs/security | Partial | Same as above. |
+| threat model docs | claimed | docs file exists | doc checks only | none explicit | n/a | `docs/security/rest-api.md` | Strong | Keep updated with runtime reality. |
+| security audit / CI checks | claimed | workflow config | CI workflows present | yes | n/a | README/docs | Partial | Avoid overstating "enterprise-grade" guarantees. |
+| fuzz testing | claimed | `fuzz/` target exists | no regular CI fuzz run proven | none strong | n/a | README/docs | Basic | Mark as available locally, not continuous CI yet. |
+| Docker/GHCR | claimed | Dockerfile + release workflow job | docker smoke in CI | yes | not Windows artifact | docs mention container usage | Partial | Optional channel; not primary install path. |
+| Windows release ZIP | should be canonical | release workflow assembles canonical zip | verify script + smoke checks | release workflow validates | yes | README/distribution docs | Strong | Primary supported distribution path. |
+| MSI/installer | previously claimed | no active MSI build in release workflow | none | none | not shipped | old docs referenced | Not implemented | Claims removed; ZIP is canonical. |
+| WinGet readiness | planned | templates under `packaging/winget` | dry-run update script | can be validated manually | references release zip | distribution docs | Partial | Manual submission only (no auto-submit). |
+| Scoop readiness | planned | `packaging/scoop/windows-mtr.json` | dry-run script | manual test path documented | references release zip | distribution docs | Partial | Not yet published in a bucket. |
+| Chocolatey readiness | planned | nuspec/template present | dry-run script | manual packaging docs | references release zip | distribution docs | Partial | Not yet published on chocolatey.org. |
+| Linux runtime support | often implied | Rust code may compile, but not primary target | limited smoke job only | ubuntu smoke exists | no Linux release artifact | docs now defer | Basic | Do not claim full Linux packaging/runtime yet. |
+| macOS runtime support | sometimes implied | no explicit target workflow seen | none clear | none clear | none | docs now defer | Not implemented | Defer Homebrew until validated runtime support. |
+
+## Summary
+
+- Canonical deliverable is now the GitHub Release ZIP.
+- Package manager manifests are metadata layers that should reference the canonical ZIP + SHA256.
+- Claims were reduced where validation is incomplete (especially installer, cross-platform maturity, and enterprise wording).

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,104 @@
+# Distribution model
+
+## Canonical release model
+
+**Source of truth:** GitHub Releases  
+**Canonical artifact:** `windows-mtr-x86_64.zip`
+
+Canonical ZIP contents:
+- `mtr.exe`
+- `windows-mtr.exe`
+- `README.txt`
+- `SHA256SUM`
+
+Package managers must point to this ZIP and verify SHA256. They should not become separate binary sources.
+
+See also: [docs/capability-validation.md](capability-validation.md).
+
+## Channel status
+
+| Channel | Readiness | Artifact required | Install command | Automation status | Manual steps | Known limitations |
+|---|---|---|---|---|---|---|
+| GitHub Releases | Supported / canonical | `windows-mtr-x86_64.zip`, `SHA256SUM` | download + extract | automated in release workflow | publish tag release | Windows-focused path |
+| WinGet | Planned / manifest template prepared | canonical ZIP URL + SHA256 | `winget install --manifest .\packaging\winget` | local update script only | manual PR to `microsoft/winget-pkgs` | not auto-submitted |
+| Scoop | Planned / manifest template prepared | canonical ZIP URL + hash | `scoop install .\packaging\scoop\windows-mtr.json` | local update script only | optional future bucket publish | not live in public bucket |
+| Chocolatey | Planned / portable template prepared | canonical ZIP URL + checksum metadata | `choco pack` then local install | local update script only | manual push to chocolatey.org | not published yet |
+| crates.io | Future developer channel | source crate | `cargo install windows-mtr --locked` | none | requires release readiness review | compiles locally; not ideal for normal Windows users |
+| cargo-binstall | Future | stable GitHub artifact naming | `cargo binstall windows-mtr` (future) | none | enable after artifact naming stability | deferred |
+| Docker/GHCR | Optional / partial | container image | `docker run --rm ghcr.io/benjisho/windows-mtr:latest --help` | workflow exists | optional manual Docker Hub setup | raw probe modes may need NET_RAW/privileged capabilities |
+| Homebrew tap | Deferred | N/A | N/A | none | defer until macOS/Linux runtime validation | avoid `mtr` naming conflict |
+| Snap | Deferred | N/A | N/A | none | defer until Linux runtime validation | avoid premature support claims |
+| .deb | Deferred | N/A | N/A | none | defer until Linux runtime validation | avoid `/usr/bin/mtr` collision |
+| .rpm | Deferred | N/A | N/A | none | defer until Linux runtime validation | avoid `/usr/bin/mtr` collision |
+
+## WinGet maintainer notes
+
+Templates:
+- `packaging/winget/windows-mtr.yaml`
+- `packaging/winget/windows-mtr.installer.yaml`
+- `packaging/winget/windows-mtr.locale.en-US.yaml`
+
+Validation/testing:
+```powershell
+winget validate .\packaging\winget
+winget install --manifest .\packaging\winget
+```
+
+Update helper:
+```powershell
+scripts/release/update-winget-manifest.ps1 -Version <x.y.z> -Sha256 <SHA256>
+```
+
+## Scoop maintainer notes
+
+Manifest:
+- `packaging/scoop/windows-mtr.json`
+
+Local test:
+```powershell
+scoop install .\packaging\scoop\windows-mtr.json
+```
+
+Future bucket flow:
+```powershell
+scoop bucket add benjisho https://github.com/benjisho/scoop-bucket
+scoop install windows-mtr
+```
+
+Update helper:
+```powershell
+scripts/release/update-scoop-manifest.ps1 -Version <x.y.z> -Sha256 <SHA256>
+```
+
+## Chocolatey maintainer notes
+
+Templates:
+- `packaging/chocolatey/windows-mtr.portable.nuspec`
+- `packaging/chocolatey/tools/VERIFICATION.txt.template`
+
+Local workflow:
+```powershell
+choco pack
+choco install windows-mtr.portable --source . -y
+choco push windows-mtr.portable.<VERSION>.nupkg --source https://push.chocolatey.org/
+```
+
+Update helper:
+```powershell
+scripts/release/update-chocolatey.ps1 -Version <x.y.z> -Sha256 <SHA256>
+```
+
+## Official references
+
+- WinGet packaging docs: https://learn.microsoft.com/windows/package-manager/package/
+- WinGet manifest schema docs: https://learn.microsoft.com/windows/package-manager/package/manifest
+- MSIX packaging guidance: https://learn.microsoft.com/windows/msix/
+- Chocolatey package creation: https://docs.chocolatey.org/en-us/create/create-packages/
+- Scoop manifest docs: https://github.com/ScoopInstaller/Scoop/wiki/App-Manifests
+- crates.io/cargo install docs: https://doc.rust-lang.org/cargo/commands/cargo-install.html
+- cargo-binstall docs: https://github.com/cargo-bins/cargo-binstall
+- Docker image publishing docs: https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+- Homebrew formula docs (deferred): https://docs.brew.sh/Formula-Cookbook
+- Snapcraft docs (deferred): https://snapcraft.io/docs
+- Debian packaging notes (deferred): https://www.debian.org/doc/manuals/maint-guide/
+- RPM packaging guide (deferred): https://rpm.org/docs/

--- a/packaging/chocolatey/tools/VERIFICATION.txt.template
+++ b/packaging/chocolatey/tools/VERIFICATION.txt.template
@@ -1,0 +1,10 @@
+VERIFICATION
+============
+
+1. Download the canonical release ZIP from:
+   RELEASE_URL
+2. Verify SHA256:
+   REPLACE_WITH_RELEASE_SHA256
+3. Compare with SHA256SUM from the same GitHub Release.
+
+This portable package should reference the same binary artifact published to GitHub Releases.

--- a/packaging/chocolatey/windows-mtr.portable.nuspec
+++ b/packaging/chocolatey/windows-mtr.portable.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>windows-mtr.portable</id>
+    <version>VERSION</version>
+    <title>windows-mtr (Portable)</title>
+    <authors>Benji Shohet</authors>
+    <projectUrl>https://github.com/benjisho/windows-mtr</projectUrl>
+    <projectSourceUrl>https://github.com/benjisho/windows-mtr</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/benjisho/windows-mtr/issues</bugTrackerUrl>
+    <license type="expression">Apache-2.0</license>
+    <tags>network diagnostics mtr traceroute ping windows</tags>
+    <summary>Portable windows-mtr package using the canonical GitHub Release ZIP.</summary>
+    <description>windows-mtr portable package that installs mtr.exe and windows-mtr.exe from GitHub Releases.</description>
+    <releaseNotes>https://github.com/benjisho/windows-mtr/releases/tag/vVERSION</releaseNotes>
+  </metadata>
+</package>

--- a/packaging/scoop/windows-mtr.json
+++ b/packaging/scoop/windows-mtr.json
@@ -1,13 +1,26 @@
 {
-  "version": "1.1.3",
-  "description": "Windows-native drop-in replacement for Linux mtr",
+  "version": "VERSION",
+  "description": "Windows MTR diagnostics CLI with embedded Trippy",
   "homepage": "https://github.com/benjisho/windows-mtr",
   "license": "Apache-2.0",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/benjisho/windows-mtr/releases/download/v1.1.3/windows-mtr-1.1.3-x86_64-pc-windows-msvc.zip",
+      "url": "https://github.com/benjisho/windows-mtr/releases/download/vVERSION/windows-mtr-x86_64.zip",
       "hash": "REPLACE_WITH_RELEASE_SHA256"
     }
   },
-  "bin": "mtr.exe"
+  "bin": [
+    "mtr.exe",
+    "windows-mtr.exe"
+  ],
+  "checkver": {
+    "github": "https://github.com/benjisho/windows-mtr"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/benjisho/windows-mtr/releases/download/v$version/windows-mtr-x86_64.zip"
+      }
+    }
+  }
 }

--- a/packaging/winget/windows-mtr.installer.yaml
+++ b/packaging/winget/windows-mtr.installer.yaml
@@ -1,13 +1,15 @@
-PackageIdentifier: benjisho.windows-mtr
-PackageVersion: 1.1.3
+PackageIdentifier: BenjiShohet.WindowsMTR
+PackageVersion: VERSION
 InstallerType: zip
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/benjisho/windows-mtr/releases/download/v1.1.3/windows-mtr-1.1.3-x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/benjisho/windows-mtr/releases/download/vVERSION/windows-mtr-x86_64.zip
     InstallerSha256: REPLACE_WITH_RELEASE_SHA256
     NestedInstallerType: portable
     NestedInstallerFiles:
       - RelativeFilePath: mtr.exe
         PortableCommandAlias: mtr
+      - RelativeFilePath: windows-mtr.exe
+        PortableCommandAlias: windows-mtr
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/packaging/winget/windows-mtr.locale.en-US.yaml
+++ b/packaging/winget/windows-mtr.locale.en-US.yaml
@@ -1,9 +1,9 @@
-PackageIdentifier: benjisho.windows-mtr
-PackageVersion: 1.1.3
+PackageIdentifier: BenjiShohet.WindowsMTR
+PackageVersion: VERSION
 PackageLocale: en-US
 Publisher: Benji Shohet
 PackageName: windows-mtr
-ShortDescription: Windows-native drop-in replacement for Linux mtr with embedded Trippy runtime.
+ShortDescription: Windows MTR diagnostics CLI with embedded Trippy and optional dashboard fallback UI.
 License: Apache-2.0
 LicenseUrl: https://github.com/benjisho/windows-mtr/blob/main/LICENSE
 ManifestType: defaultLocale

--- a/packaging/winget/windows-mtr.yaml
+++ b/packaging/winget/windows-mtr.yaml
@@ -1,5 +1,5 @@
-PackageIdentifier: benjisho.windows-mtr
-PackageVersion: 1.1.3
+PackageIdentifier: BenjiShohet.WindowsMTR
+PackageVersion: VERSION
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.6.0

--- a/scripts/release/update-chocolatey.ps1
+++ b/scripts/release/update-chocolatey.ps1
@@ -1,0 +1,16 @@
+param(
+  [string]$Version,
+  [string]$Sha256 = 'REPLACE_WITH_RELEASE_SHA256'
+)
+$ErrorActionPreference='Stop'
+if (-not $Version) {
+  $Version = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+}
+$url = "https://github.com/benjisho/windows-mtr/releases/download/v$Version/windows-mtr-x86_64.zip"
+$nuspec = Get-Content packaging/chocolatey/windows-mtr.portable.nuspec -Raw
+$nuspec = $nuspec.Replace('VERSION', $Version)
+Set-Content packaging/chocolatey/windows-mtr.portable.nuspec $nuspec
+$verification = Get-Content packaging/chocolatey/tools/VERIFICATION.txt.template -Raw
+$verification = $verification.Replace('VERSION', $Version).Replace('REPLACE_WITH_RELEASE_SHA256', $Sha256).Replace('RELEASE_URL', $url)
+Set-Content packaging/chocolatey/tools/VERIFICATION.txt.template $verification
+Write-Host "Updated Chocolatey templates for version $Version"

--- a/scripts/release/update-scoop-manifest.ps1
+++ b/scripts/release/update-scoop-manifest.ps1
@@ -1,0 +1,15 @@
+param(
+  [string]$Version,
+  [string]$Sha256 = 'REPLACE_WITH_RELEASE_SHA256'
+)
+$ErrorActionPreference='Stop'
+if (-not $Version) {
+  $Version = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+}
+$url = "https://github.com/benjisho/windows-mtr/releases/download/v$Version/windows-mtr-x86_64.zip"
+$json = Get-Content packaging/scoop/windows-mtr.json -Raw | ConvertFrom-Json
+$json.version = $Version
+$json.architecture.'64bit'.url = $url
+$json.architecture.'64bit'.hash = $Sha256
+$json | ConvertTo-Json -Depth 8 | Set-Content packaging/scoop/windows-mtr.json
+Write-Host "Updated Scoop manifest for version $Version"

--- a/scripts/release/update-winget-manifest.ps1
+++ b/scripts/release/update-winget-manifest.ps1
@@ -1,0 +1,16 @@
+param(
+  [string]$Version,
+  [string]$Sha256 = 'REPLACE_WITH_RELEASE_SHA256'
+)
+$ErrorActionPreference='Stop'
+if (-not $Version) {
+  $Version = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"([^"]+)"').Matches[0].Groups[1].Value
+}
+$baseUrl = "https://github.com/benjisho/windows-mtr/releases/download/v$Version/windows-mtr-x86_64.zip"
+(Get-Content packaging/winget/windows-mtr.yaml -Raw).Replace('VERSION', $Version) | Set-Content packaging/winget/windows-mtr.yaml
+$content = Get-Content packaging/winget/windows-mtr.installer.yaml -Raw
+$content = $content.Replace('VERSION', $Version).Replace('REPLACE_WITH_RELEASE_SHA256', $Sha256)
+$content = [regex]::Replace($content, 'InstallerUrl:\s*.+', "InstallerUrl: $baseUrl")
+Set-Content packaging/winget/windows-mtr.installer.yaml $content
+(Get-Content packaging/winget/windows-mtr.locale.en-US.yaml -Raw).Replace('VERSION', $Version) | Set-Content packaging/winget/windows-mtr.locale.en-US.yaml
+Write-Host "Updated WinGet manifests for version $Version"

--- a/scripts/release/verify-release-artifacts.ps1
+++ b/scripts/release/verify-release-artifacts.ps1
@@ -1,0 +1,51 @@
+param(
+  [string]$ZipPath = "dist/windows-mtr-x86_64.zip",
+  [string]$ShaPath = "dist/bundle/SHA256SUM"
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path $ZipPath)) { throw "Missing ZIP: $ZipPath" }
+if (-not (Test-Path $ShaPath)) { throw "Missing SHA file: $ShaPath" }
+
+$extractDir = Join-Path ([System.IO.Path]::GetTempPath()) ("windows-mtr-release-" + [System.Guid]::NewGuid().ToString("N"))
+Expand-Archive -Path $ZipPath -DestinationPath $extractDir -Force
+
+$expected = @('mtr.exe','windows-mtr.exe','README.txt','SHA256SUM')
+foreach ($name in $expected) {
+  if (-not (Test-Path (Join-Path $extractDir $name))) {
+    throw "ZIP missing expected file: $name"
+  }
+}
+
+$readme = Get-Content (Join-Path $extractDir 'README.txt') -Raw
+if ($readme -notmatch '\\.\\mtr\.exe\s+8\.8\.8\.8') { throw 'README.txt missing expected mtr.exe command' }
+if ($readme -notmatch '\\.\\windows-mtr\.exe\s+-r\s+-c\s+10\s+8\.8\.8\.8') { throw 'README.txt missing expected windows-mtr.exe command' }
+
+$shaEntries = Get-Content $ShaPath | Where-Object { $_.Trim() -ne '' }
+if ($shaEntries.Count -lt 3) { throw 'SHA256SUM must include at least zip and two exe entries' }
+
+foreach ($entry in $shaEntries) {
+  $parts = $entry -split '\s+', 2
+  if ($parts.Count -ne 2) { throw "Invalid SHA256SUM line: $entry" }
+  $hash = $parts[0].ToLower()
+  $file = $parts[1].Trim()
+  $candidate = if ($file -eq 'windows-mtr-x86_64.zip') { $ZipPath } else { Join-Path $extractDir $file }
+  if (-not (Test-Path $candidate)) { throw "SHA entry references missing file: $file" }
+  $actual = (Get-FileHash $candidate -Algorithm SHA256).Hash.ToLower()
+  if ($actual -ne $hash) { throw "SHA mismatch for $file" }
+}
+
+$manifestFiles = @(
+  'packaging/winget/windows-mtr.installer.yaml',
+  'packaging/scoop/windows-mtr.json',
+  'packaging/chocolatey/windows-mtr.portable.nuspec'
+)
+foreach ($mf in $manifestFiles) {
+  if (-not (Test-Path $mf)) { throw "Missing packaging manifest: $mf" }
+  $content = Get-Content $mf -Raw
+  if ($content -notmatch 'windows-mtr-x86_64\.zip') {
+    throw "Manifest does not reference canonical ZIP name: $mf"
+  }
+}
+
+Write-Host 'Release artifact validation passed.'

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use windows_mtr::service::rest_api::{AuthStrategy, RestApiConfig};
 use windows_mtr::service::rest_server::run_rest_api_server;
 use windows_mtr::service::{
-    EnhancedUiConfig, JsonOutput, ProbeError, ProbeRequest, UiMode, build_probe_plan,
-    run_embedded_trippy,
+    EnhancedUiConfig, JsonOutput, ProbeError, ProbeRequest, UiMode, build_json_snapshot_args,
+    build_probe_plan, run_embedded_trippy,
 };
 
 mod error;
@@ -170,7 +170,7 @@ struct TraceCli {
     )]
     trippy_flags: Option<String>,
 
-    /// UI preset for interactive mode
+    /// UI preset for interactive mode (use `dashboard`; `native` is a deprecated alias)
     #[arg(long = "ui", value_enum, default_value_t = UiPreset::Default)]
     ui: UiPreset,
 
@@ -207,7 +207,8 @@ struct TraceCli {
 enum UiPreset {
     Default,
     Enhanced,
-    Native,
+    #[value(alias = "native")]
+    Dashboard,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
@@ -262,7 +263,7 @@ fn windows_exit_diagnostic(exit_code: i32) -> Option<&'static str> {
     match exit_code as u32 {
         0xC0000005 => Some(
             "Detected a Windows access violation from the embedded Trippy UI. \
-             Retry with `mtr --ui native <target>` or use report mode (`mtr -r -c 5 <target>`).",
+             Retry with `mtr --ui dashboard <target>` or use report mode (`mtr -r -c 5 <target>`).",
         ),
         _ => None,
     }
@@ -356,7 +357,7 @@ fn ui_mode_from_cli(ui: UiPreset) -> UiMode {
     match ui {
         UiPreset::Default => UiMode::Default,
         UiPreset::Enhanced => UiMode::Enhanced,
-        UiPreset::Native => UiMode::Native,
+        UiPreset::Dashboard => UiMode::Dashboard,
     }
 }
 
@@ -453,8 +454,12 @@ fn main() -> anyhow::Result<()> {
         .map_err(|error| anyhow::anyhow!(error.to_string()))
         .context("invalid command-line options")?;
 
-    if plan.ui_mode == UiMode::Native {
-        let code = native_ui::run_native_ui(&plan.validated_host, &plan.trippy_args)?;
+    if plan.ui_mode == UiMode::Dashboard {
+        let snapshot_args = build_json_snapshot_args(&request, &plan.validated_host)
+            .map_err(to_cli_error)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+            .context("invalid dashboard/json snapshot options")?;
+        let code = native_ui::run_native_ui(&plan.validated_host, &snapshot_args)?;
         process::exit(code);
     }
 
@@ -743,5 +748,16 @@ mod tests {
             err.to_string()
                 .contains("missing host argument (or run with --api)")
         );
+    }
+
+    #[test]
+    fn cli_accepts_dashboard_ui_and_native_alias() {
+        let dashboard = Cli::try_parse_from(["mtr", "--ui", "dashboard", "8.8.8.8"])
+            .expect("dashboard preset should parse");
+        assert_eq!(dashboard.trace.ui, UiPreset::Dashboard);
+
+        let native_alias = Cli::try_parse_from(["mtr", "--ui", "native", "8.8.8.8"])
+            .expect("native alias should parse");
+        assert_eq!(native_alias.trace.ui, UiPreset::Dashboard);
     }
 }

--- a/src/native_ui.rs
+++ b/src/native_ui.rs
@@ -99,7 +99,7 @@ impl NativeUiApp {
 }
 
 pub fn run_native_ui(target: &str, trippy_args: &[String]) -> anyhow::Result<i32> {
-    enable_raw_mode().context("failed to enable raw mode for native UI")?;
+    enable_raw_mode().context("failed to enable raw mode for dashboard UI")?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen).context("failed to enter alternate screen")?;
 
@@ -183,19 +183,11 @@ fn fetch_hops_snapshot(base_args: &[String], target: &str) -> anyhow::Result<Vec
     // not for any trust or authorization decision.
     let current_exe =
         // nosemgrep: rust.lang.security.current-exe.current-exe
-        env::current_exe().context("failed to locate current executable for native UI polling")?;
-
-    let mut args = sanitize_args_for_json_snapshot(base_args);
-    args.extend([
-        "--mode".to_string(),
-        "json".to_string(),
-        "--report-cycles".to_string(),
-        "1".to_string(),
-    ]);
+        env::current_exe().context("failed to locate current executable for dashboard polling")?;
 
     let output = Command::new(&current_exe)
         .env(EMBEDDED_TRIPPY_ENV, "1")
-        .args(args.iter().skip(1))
+        .args(base_args.iter().skip(1))
         .output()
         .context("failed to run embedded trippy JSON poll")?;
 
@@ -208,28 +200,6 @@ fn fetch_hops_snapshot(base_args: &[String], target: &str) -> anyhow::Result<Vec
         .context("failed to parse trippy JSON poll output")?;
 
     Ok(extract_hops(&value, target))
-}
-
-fn sanitize_args_for_json_snapshot(base_args: &[String]) -> Vec<String> {
-    let mut cleaned = Vec::with_capacity(base_args.len());
-    let mut skip_next = false;
-    let pair_flags = ["--mode", "--report-cycles"];
-
-    for token in base_args {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-
-        if pair_flags.contains(&token.as_str()) {
-            skip_next = true;
-            continue;
-        }
-
-        cleaned.push(token.clone());
-    }
-
-    cleaned
 }
 
 fn extract_hops(value: &Value, target: &str) -> Vec<HopStat> {
@@ -251,7 +221,7 @@ fn extract_hops(value: &Value, target: &str) -> Vec<HopStat> {
                 format!("hop-{hop}")
             }
         });
-        let loss_pct = read_f64(item, &["loss_pct", "loss", "loss_percentage"]).unwrap_or(0.0);
+        let loss_pct = read_loss_pct(item).unwrap_or(0.0);
         let avg_ms =
             read_f64(item, &["avg_ms", "avg", "average_ms", "last_ms", "last"]).unwrap_or(0.0);
         let best_ms = read_f64(item, &["best_ms", "best", "min_ms", "min"]).unwrap_or(avg_ms);
@@ -268,10 +238,6 @@ fn extract_hops(value: &Value, target: &str) -> Vec<HopStat> {
     }
 
     hops
-}
-
-fn normalize_percent(value: f64) -> f64 {
-    if value < 1.0 { value * 100.0 } else { value }
 }
 
 fn find_hop_array(value: &Value) -> Option<&Vec<Value>> {
@@ -304,6 +270,18 @@ fn find_hop_array(value: &Value) -> Option<&Vec<Value>> {
         }
         _ => None,
     }
+}
+
+fn read_loss_pct(item: &Value) -> Option<f64> {
+    if let Some(value) = read_f64(item, &["loss_pct", "loss_percentage", "loss"]) {
+        return Some(value);
+    }
+
+    read_f64(item, &["loss_ratio"]).map(|ratio| ratio * 100.0)
+}
+
+fn normalize_percent(value: f64) -> f64 {
+    value
 }
 
 fn looks_like_hop_array(array: &[Value]) -> bool {
@@ -378,7 +356,7 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
     let tabs = Tabs::new(titles)
         .block(
             Block::default()
-                .title(format!("windows-mtr native UI ({})", app.target))
+                .title(format!("windows-mtr dashboard ({})", app.target))
                 .borders(Borders::ALL),
         )
         .select(app.tab_index)
@@ -589,19 +567,15 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn sanitize_args_for_json_snapshot_strips_mode_and_cycles_pairs() {
-        let args = vec![
-            "mtr".to_string(),
-            "--mode".to_string(),
-            "tui".to_string(),
-            "--report-cycles".to_string(),
-            "10".to_string(),
-            "--udp".to_string(),
-            "example.com".to_string(),
-        ];
+    fn read_loss_pct_distinguishes_percent_and_ratio_fields() {
+        let percent = json!({"loss_pct": 0.5});
+        assert_eq!(read_loss_pct(&percent), Some(0.5));
 
-        let cleaned = sanitize_args_for_json_snapshot(&args);
-        assert_eq!(cleaned, vec!["mtr", "--udp", "example.com"]);
+        let percent_alt = json!({"loss_percentage": 5.0});
+        assert_eq!(read_loss_pct(&percent_alt), Some(5.0));
+
+        let ratio = json!({"loss_ratio": 0.05});
+        assert_eq!(read_loss_pct(&ratio), Some(5.0));
     }
 
     #[test]
@@ -638,10 +612,20 @@ mod tests {
 
         assert_eq!(hops[1].hop, 2);
         assert_eq!(hops[1].host, "target.example");
-        assert_eq!(hops[1].loss_pct, 50.0);
+        assert_eq!(hops[1].loss_pct, 0.5);
         assert_eq!(hops[1].best_ms, 15.0);
         assert_eq!(hops[1].avg_ms, 20.0);
         assert_eq!(hops[1].worst_ms, 25.0);
+    }
+
+    #[test]
+    fn extract_hops_parses_trippy_013_fixture_shape() {
+        let payload: Value =
+            serde_json::from_str(include_str!("../tests/fixtures/trippy_013_report.json"))
+                .expect("fixture should parse");
+        let hops = extract_hops(&payload, "dns.google");
+        assert!(!hops.is_empty());
+        assert_eq!(hops[0].hop, 1);
     }
 
     #[test]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -11,7 +11,7 @@ use std::process::{Command, Stdio};
 pub enum UiMode {
     Default,
     Enhanced,
-    Native,
+    Dashboard,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -112,12 +112,12 @@ pub fn verify_options(request: &ProbeRequest) -> Result<(), ProbeError> {
         ));
     }
 
-    if (request.ui_mode == UiMode::Enhanced || request.ui_mode == UiMode::Native)
+    if (request.ui_mode == UiMode::Enhanced || request.ui_mode == UiMode::Dashboard)
         && (request.report || request.json_output.is_some())
     {
         let ui_name = match request.ui_mode {
             UiMode::Enhanced => "enhanced",
-            UiMode::Native => "native",
+            UiMode::Dashboard => "dashboard",
             UiMode::Default => "default",
         };
 
@@ -184,6 +184,23 @@ pub fn build_probe_plan(request: &ProbeRequest) -> Result<ProbePlan, ProbeError>
         json_output: request.json_output,
         ui_mode: request.ui_mode,
     })
+}
+
+fn is_dashboard_conflicting_trippy_flag(token: &str) -> bool {
+    matches!(
+        token,
+        "--mode"
+            | "--report-cycles"
+            | "--tui-latency-warn-threshold"
+            | "--tui-latency-bad-threshold"
+            | "--tui-loss-warn-threshold"
+            | "--tui-loss-bad-threshold"
+            | "--tui-row-coloring"
+            | "--tui-hop-trend"
+            | "--tui-summary-jitter"
+            | "--tui-summary-percentiles"
+            | "--tui-address-mode"
+    )
 }
 
 fn mode_from_request(request: &ProbeRequest) -> &'static str {
@@ -353,6 +370,88 @@ pub fn build_embedded_trippy_args(
 
     if let Some(extra) = &request.trippy_flags {
         trippy_args.extend(parse_passthrough_flags(extra)?);
+    }
+
+    trippy_args.push(host.to_string());
+    Ok(trippy_args)
+}
+
+pub fn build_json_snapshot_args(
+    request: &ProbeRequest,
+    host: &str,
+) -> Result<Vec<String>, ProbeError> {
+    let mut trippy_args = vec![
+        "mtr".to_string(),
+        "--mode".to_string(),
+        "json".to_string(),
+        "--report-cycles".to_string(),
+        "1".to_string(),
+    ];
+
+    if request.tcp {
+        trippy_args.push("--tcp".to_string());
+    } else if request.udp {
+        trippy_args.push("--udp".to_string());
+    }
+
+    if let Some(port) = request.port {
+        trippy_args.extend(["--target-port".to_string(), port.to_string()]);
+    }
+
+    if let Some(source_port) = request.source_port {
+        trippy_args.extend(["--source-port".to_string(), source_port.to_string()]);
+    }
+
+    if let Some(interval) = request.interval_seconds {
+        trippy_args.extend([
+            "--min-round-duration".to_string(),
+            duration_seconds(interval),
+        ]);
+    }
+
+    if let Some(timeout) = request.timeout_seconds {
+        trippy_args.extend(["--grace-duration".to_string(), duration_seconds(timeout)]);
+    }
+
+    if let Some(max_hops) = request.max_hops {
+        trippy_args.extend(["--max-ttl".to_string(), max_hops.to_string()]);
+    }
+
+    if request.show_asn || request.dns_lookup_as_info {
+        trippy_args.push("--dns-lookup-as-info".to_string());
+    }
+
+    if let Some(packet_size) = request.packet_size {
+        trippy_args.extend(["--packet-size".to_string(), packet_size.to_string()]);
+    }
+
+    if let Some(src) = request.src {
+        trippy_args.extend(["--source-address".to_string(), src.to_string()]);
+    }
+
+    if let Some(interface) = &request.interface {
+        trippy_args.extend(["--interface".to_string(), interface.clone()]);
+    }
+
+    if let Some(ecmp) = &request.ecmp {
+        trippy_args.extend(["--multipath-strategy".to_string(), ecmp.clone()]);
+    }
+
+    if let Some(ttl) = request.dns_cache_ttl_seconds {
+        trippy_args.extend(["--dns-ttl".to_string(), format!("{ttl}s")]);
+    }
+
+    if let Some(extra) = &request.trippy_flags {
+        let parsed = parse_passthrough_flags(extra)?;
+        if parsed
+            .iter()
+            .any(|token| is_dashboard_conflicting_trippy_flag(token))
+        {
+            return Err(ProbeError::InvalidOption(
+                "--trippy-flags cannot override dashboard/json snapshot settings".to_string(),
+            ));
+        }
+        trippy_args.extend(parsed);
     }
 
     trippy_args.push(host.to_string());

--- a/tests/fixtures/trippy_013_report.json
+++ b/tests/fixtures/trippy_013_report.json
@@ -1,0 +1,29 @@
+{
+  "report": {
+    "target": "dns.google",
+    "hops": [
+      {
+        "ttl": 1,
+        "host": "192.168.1.1",
+        "loss_pct": 0.5,
+        "sent": 1,
+        "last_ms": 1.2,
+        "avg_ms": 1.2,
+        "best_ms": 1.2,
+        "worst_ms": 1.2,
+        "stddev_ms": 0.0
+      },
+      {
+        "ttl": 2,
+        "host": "dns.google",
+        "loss_ratio": 0.05,
+        "sent": 1,
+        "last_ms": 12.7,
+        "avg_ms": 12.7,
+        "best_ms": 12.7,
+        "worst_ms": 12.7,
+        "stddev_ms": 0.0
+      }
+    ]
+  }
+}

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 use windows_mtr::service::{
     EnhancedUiConfig, JsonOutput, ProbeError, ProbeRequest, UiMode, build_embedded_trippy_args,
-    build_probe_plan, parse_passthrough_flags,
+    build_json_snapshot_args, build_probe_plan, parse_passthrough_flags,
 };
 
 fn base_request() -> ProbeRequest {
@@ -171,6 +171,32 @@ fn build_embedded_trippy_args_supports_json_mode() {
 
     let trippy_args = build_embedded_trippy_args(&request, "8.8.8.8").expect("should build");
     assert_eq!(trippy_args, vec!["mtr", "--mode", "json", "8.8.8.8"]);
+}
+
+#[test]
+fn build_json_snapshot_args_uses_json_mode_and_omits_enhanced_tui_flags() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Dashboard;
+    request.no_dns = true;
+    request.count = Some(15);
+    request.trippy_flags = Some("--verbose".to_string());
+
+    let args = build_json_snapshot_args(&request, "8.8.8.8").expect("should build");
+    assert!(args.windows(2).any(|w| w == ["--mode", "json"]));
+    assert!(args.windows(2).any(|w| w == ["--report-cycles", "1"]));
+    assert!(!args.iter().any(|a| a == "tui"));
+    assert!(!args.iter().any(|a| a.starts_with("--tui-")));
+}
+
+#[test]
+fn build_json_snapshot_args_rejects_conflicting_passthrough_flags() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Dashboard;
+    request.trippy_flags = Some("--mode tui".to_string());
+
+    let err = build_json_snapshot_args(&request, "8.8.8.8")
+        .expect_err("dashboard should reject conflicting passthrough flags");
+    assert!(matches!(err, ProbeError::InvalidOption(_)));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Resolve user confusion between the embedded Trippy TUI and the previously named `--ui native` mode by renaming and clarifying the fallback UI and its runtime strategy.
- Prevent release/distribution drift by making GitHub Releases the single canonical binary source and ensure package manifests reference that artifact.
- Ground strategic capability claims in verifiable evidence by adding a capability validation matrix and aligning docs with tested/runtime reality.

### Description
- Renamed the user-facing fallback UI to `--ui dashboard` and preserved `--ui native` as a deprecated alias while updating CLI help, diagnostics text, and tests (changes in `src/main.rs`, `src/native_ui.rs`).
- Separated concern of argument planning from rendering by adding `build_json_snapshot_args` in `src/service/mod.rs` and using it for dashboard polling instead of sanitizing/mutating TUI args at runtime in `native_ui`.
- Fixed loss percentage parsing: percent fields (`loss_pct` / `loss_percentage`) are treated as percentages while `loss_ratio` is converted to percent, and added fixture-backed parsing tests (changes in `src/native_ui.rs`, new fixture `tests/fixtures/trippy_013_report.json`).
- Reworked release workflow & packaging to produce one canonical ZIP (`windows-mtr-x86_64.zip`) containing `mtr.exe`, `windows-mtr.exe`, `README.txt`, and `SHA256SUM`, added `scripts/release/verify-release-artifacts.ps1`, and updated the release workflow and PR artifact assembly to validate names and checksums (`.github/workflows/release.yml`, `.github/workflows/ci.yml`).
- Added local dry-run helper scripts and package-manager manifest templates that point to the GitHub Release ZIP for WinGet, Scoop, and Chocolatey and documented the distribution model and capability validation (`packaging/*`, `scripts/release/*`, `docs/distribution.md`, `docs/capability-validation.md`, README/USAGE updates).

### Testing
- Ran `cargo fmt --all -- --check` and it passed.
- Ran `cargo clippy --all-targets --all-features -- -D warnings` and it passed.
- Ran `cargo test --all`; all unit, integration, and API contract tests were executed and passed, including newly added tests for dashboard arg building and loss parsing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee4366cce08330a362a89a6b6c1ed6)