### PR TITLE
docs: add post-merge status report for PR #167

### DIFF
--- a/docs/reports-pr167-status.md
+++ b/docs/reports-pr167-status.md
@@ -1,0 +1,33 @@
+# Post-merge status report for PR #167
+
+_Date: 2026-05-03_
+
+## Bottom line
+
+PR #167 is merged into `master` and the repository is in a stronger, more coherent state. The merged work aligns runtime UX naming, release/distribution strategy, and capability-validation discipline.
+
+## Confirmed outcomes
+
+- `--ui dashboard` is now the canonical fallback mode; `--ui native` remains a deprecated compatibility alias.
+- Dashboard probing now uses dedicated JSON snapshot argument construction instead of mutating interactive TUI arguments.
+- Distribution guidance now centers around one canonical GitHub Release ZIP artifact.
+- Capability-validation documentation now requires evidence across code, tests, docs, CI, and release/runtime validation before labeling capabilities as "Full".
+
+## Current strengths
+
+- UI naming is clearer and better aligned with behavior.
+- Backward compatibility for legacy `--ui native` usage is preserved.
+- Release model is easier to reason about and validate.
+- CI/security quality gates reported green in the PR summary.
+
+## Follow-up priorities
+
+1. Create a tracking issue to remove RustSec advisory ignores via dependency upgrades (notably Trippy/hickory chain).
+2. Review and soften README claims that appear stronger than current published evidence (performance and signing language).
+3. Decide whether Chocolatey remains template-only or is promoted to a fully installable package flow.
+4. Add a release-level ZIP checksum asset alongside internal archive checksums.
+5. Run real package-manager validations (`winget`, Scoop, Chocolatey) against a tagged release artifact.
+
+## Recommended next step
+
+Cut a GitHub Release from current `master`, verify the ZIP content and checksums, then validate package-manager manifests against that release.


### PR DESCRIPTION
### Motivation
- Capture and publish a concise post-merge snapshot for PR #167 summarizing UX naming, the dashboard JSON arg builder, the canonical release ZIP guidance, capability-validation discipline, and immediate follow-up priorities.

### Description
- Add `docs/reports-pr167-status.md` containing a short post-merge status report with bottom line, confirmed outcomes, current strengths, follow-up priorities, and a recommended next step to cut and validate a release.

### Testing
- Documentation-only change; no automated code tests were run in this environment and pre-commit/CI were not executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f690002f308330b573cfb72967a0e1)