### PR TITLE
docs: add post-PR-167 status report

### DIFF
--- a/docs/reports/post-pr-167-status.md
+++ b/docs/reports/post-pr-167-status.md
@@ -1,0 +1,63 @@
+# windows-mtr Status Report After PR #167
+
+_Date: 2026-05-03_
+
+## Bottom line
+
+PR #167 is merged and delivered the intended architecture cleanup:
+
+- `--ui dashboard` is now the canonical name for the JSON snapshot fallback mode.
+- `--ui native` remains as a deprecated compatibility alias.
+- Release distribution now centers on one canonical GitHub Releases ZIP.
+- Capability claims are tracked against code, tests, docs, CI, and release/runtime evidence.
+
+## Confirmed outcomes
+
+### Runtime UX and naming
+
+Old behavior was misleading (`native` was not actually an embedded native UI). The current mapping is coherent:
+
+- `--ui default` → embedded Trippy TUI
+- `--ui enhanced` → embedded Trippy TUI + windows-mtr presets
+- `--ui dashboard` → experimental JSON snapshot dashboard fallback
+- `--ui native` → deprecated compatibility alias
+
+### Dashboard argument construction
+
+Dashboard mode now uses a dedicated JSON snapshot argument builder (`build_json_snapshot_args`) instead of mutating TUI arguments. Conflicting flags (for example `--mode`, `--report-cycles`, JSON mode flags, and `--tui-*`) are explicitly rejected.
+
+### Release artifact model
+
+Canonical distribution source is GitHub Releases ZIP:
+
+- `windows-mtr-x86_64.zip`
+  - `mtr.exe`
+  - `windows-mtr.exe`
+  - `README.txt`
+  - `SHA256SUM`
+
+Validation scripts now check ZIP layout, checksums, and package-manager manifest alignment.
+
+### Validation and trust layer
+
+Repository now includes capability validation guidance that requires evidence across:
+
+- implementation code
+- tests
+- CI outcomes
+- docs
+- release/runtime validation
+
+## Remaining follow-up items
+
+1. Track and remove RustSec ignore entries by upgrading the Trippy/hickory dependency chain.
+2. Soften or evidence README performance and security-signing claims.
+3. Decide whether Chocolatey remains template-only or becomes fully installable.
+4. Add/publish ZIP-level checksum assets for package-manager consumption.
+5. Validate WinGet/Scoop/Chocolatey flows against a real tagged release.
+6. Promote capability statuses only after release/runtime validation is completed.
+7. Optionally rename remaining internal `native_*` symbols to `dashboard_*` later.
+
+## Recommended next step
+
+Cut the next GitHub Release from current `master`, verify the ZIP artifact contents/checksums, then run package-manager validation against that concrete release artifact.


### PR DESCRIPTION
### Motivation
- Create a durable in-repo report that captures the post-merge state after PR #167, documents the key architectural outcomes, and records follow-up work and the recommended next steps.

### Description
- Add `docs/reports/post-pr-167-status.md` which summarizes the `--ui dashboard` naming change (with `native` as a deprecated alias), the dedicated `build_json_snapshot_args` dashboard arg builder, the canonical GitHub Releases ZIP distribution model, the capability validation/trust layer, and a concise follow-up backlog and recommended next actions.

### Testing
- Ran repository inspection and file checks including `sed -n '1,120p' README.md`, `sed -n '1,120p' USAGE.md`, `nl -ba docs/reports/post-pr-167-status.md`, `git status --short`, and created the commit with `git commit`, all of which completed successfully; no runtime or CI changes were required for this documentation-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f690002f308330b573cfb72967a0e1)