### PR TITLE
Soft‑disable unsupported enhanced UI and clarify dashboard as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Updated documentation and roadmap to reflect delivered v2.0 capabilities.
 
 ### Fixed
+- Stopped passing unsupported enhanced `--tui-*` flags to bundled Trippy 0.13.0 and soft-disabled `--ui enhanced` with actionable guidance.
+- Clarified `--ui dashboard` as an experimental fallback dashboard (JSON snapshot polling), not parity with embedded Trippy TUI.
+
+### Fixed
 - Hardened security workflow with a pinned Rust toolchain, explicit `cargo-deny` policy file, and an always-on GitHub Actions job summary.
 - Tuned `cargo-deny` policy to handle known transitive advisories and unavoidable duplicate crates in the Trippy 0.13 dependency graph.
 - Added `cargo-audit` policy configuration with documented temporary ignores for transitive upstream advisories in the current Trippy 0.13 stack.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-Windows MTR is a Windows-focused network diagnostics CLI inspired by Linux mtr. It embeds Trippy for probing/reporting and includes an experimental dashboard fallback for terminals where the embedded interactive TUI crashes.
+Windows MTR is a Windows-focused network diagnostics CLI inspired by Linux mtr. It embeds Trippy for probing/reporting. The default interactive experience is the embedded Trippy TUI; `--ui dashboard` is an experimental fallback for terminals where the TUI crashes.
 
 ## 📚 Table of Contents
 
@@ -199,7 +199,7 @@ mtr 8.8.8.8
 > [!TIP]
 > From the canonical ZIP, use `.\mtr.exe` or `.\windows-mtr.exe` directly.
 
-### Dashboard fallback UI (experimental)
+### Dashboard fallback UI (experimental, limited)
 
 ```bash
 mtr --ui dashboard 8.8.8.8

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,7 +34,7 @@ mtr [options] <hostname-or-ip>
 | `-n` | Disable reverse DNS rendering (show IP only) |
 | `-b, --show-asn` | Enable ASN lookup/rendering |
 | `-z` | DNS ASN lookup shortcut |
-| `--ui <default\|enhanced\|dashboard>` | Interactive UI preset (enhanced enables diagnostic overlays) |
+| `--ui <default|enhanced|dashboard>` | Interactive UI preset (`enhanced` is unavailable with bundled Trippy 0.13.0; `dashboard` is fallback) |
 
 ## Dashboard UI (experimental fallback)
 
@@ -69,9 +69,9 @@ For stable diagnostics, use report mode:
 .\mtr.exe -n -r -c 5 8.8.8.8
 ```
 
-## Enhanced UI options
+## Enhanced UI options (currently unavailable with bundled Trippy 0.13.0)
 
-The `enhanced` preset applies defaults tuned for quicker incident triage:
+`--ui enhanced` is currently soft-disabled because bundled Trippy 0.13.0 does not support the required `--tui-*` flags. Use default mode (`mtr <target>`) or `--ui dashboard` fallback.
 
 - Latency color bands: `--latency-warn-ms 100`, `--latency-bad-ms 250`
 - Loss color bands: `--loss-warn-pct 2`, `--loss-bad-pct 5`
@@ -126,12 +126,6 @@ The `enhanced` preset applies defaults tuned for quicker incident triage:
 # Interactive TUI
 mtr 8.8.8.8
 
-# Interactive TUI (enhanced diagnostic preset)
-mtr --ui enhanced 8.8.8.8
-
-# Enhanced mode with custom threshold bands + toggles
-mtr --ui enhanced --latency-warn-ms 80 --latency-bad-ms 180 --loss-warn-pct 1 --loss-bad-pct 3 --enhanced-sparklines off 8.8.8.8
-
 # TCP report
 mtr -T -P 443 -c 15 -r github.com
 
@@ -145,7 +139,7 @@ mtr -S 192.0.2.10 -s 128 8.8.4.4
 mtr --trippy-flags "--log-format json --verbose --tui-refresh-rate 150ms" 8.8.8.8
 ```
 
-## Default vs enhanced mode (side-by-side)
+## Default mode vs dashboard fallback
 
 | Default mode | Enhanced mode |
 |---|---|

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ const EMBEDDED_TRIPPY_ENV: &str = "WINDOWS_MTR_EMBEDDED_TRIPPY";
   windows-mtr --json -c 20 example.com          # JSON report output
   windows-mtr --api                              # Run REST API runtime
   windows-mtr --trippy-flags '--tui-refresh-rate 150ms' example.com
-  windows-mtr --ui dashboard 8.8.8.8          # Experimental dashboard fallback (alias: --ui native)")]
+  windows-mtr --ui dashboard 8.8.8.8          # Experimental fallback dashboard (alias: --ui native)")]
 struct Cli {
     /// Run in REST API mode instead of probe CLI mode
     #[arg(long = "api")]
@@ -171,7 +171,7 @@ struct TraceCli {
     )]
     trippy_flags: Option<String>,
 
-    /// UI preset for interactive mode (`dashboard` is an experimental fallback; `native` is a deprecated alias)
+    /// UI preset for interactive mode (`enhanced` is currently unavailable with bundled Trippy 0.13.0; `dashboard`/`native` are fallback modes)
     #[arg(long = "ui", value_enum, default_value_t = UiPreset::Default)]
     ui: UiPreset,
 

--- a/src/native_ui.rs
+++ b/src/native_ui.rs
@@ -354,7 +354,7 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
     let tabs = Tabs::new(titles)
         .block(
             Block::default()
-                .title(format!("windows-mtr dashboard ({})", app.target))
+                .title(dashboard_title(&app.target))
                 .borders(Borders::ALL),
         )
         .select(app.tab_index)
@@ -379,8 +379,12 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
     frame.render_widget(help, chunks[2]);
 }
 
+fn dashboard_title(target: &str) -> String {
+    format!("windows-mtr fallback dashboard ({target})")
+}
+
 fn build_help_text(app: &NativeUiApp) -> String {
-    let base = "Controls: ←/→ or Tab switch tabs • q quits";
+    let base = "Fallback dashboard: JSON snapshot polling with limited fields. For full interactive UI use default mode (`mtr <target>`). Controls: ←/→ or Tab switch tabs • q quits";
     let mut notes = Vec::new();
 
     if app.hops.is_empty() {
@@ -659,7 +663,15 @@ mod tests {
 
         assert_eq!(
             build_help_text(&app),
-            "Controls: ←/→ or Tab switch tabs • q quits"
+            "Fallback dashboard: JSON snapshot polling with limited fields. For full interactive UI use default mode (`mtr <target>`). Controls: ←/→ or Tab switch tabs • q quits"
+        );
+    }
+
+    #[test]
+    fn dashboard_title_uses_fallback_wording() {
+        assert_eq!(
+            dashboard_title("8.8.8.8"),
+            "windows-mtr fallback dashboard (8.8.8.8)"
         );
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -133,6 +133,12 @@ pub fn verify_options(request: &ProbeRequest) -> Result<(), ProbeError> {
     }
 
     if request.ui_mode == UiMode::Enhanced {
+        return Err(ProbeError::InvalidOption(
+            "enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback".to_string(),
+        ));
+    }
+
+    if request.ui_mode == UiMode::Enhanced {
         if request.enhanced_ui.latency_warn_ms >= request.enhanced_ui.latency_bad_ms {
             return Err(ProbeError::InvalidOption(
                 "--latency-warn-ms must be lower than --latency-bad-ms".to_string(),
@@ -147,28 +153,6 @@ pub fn verify_options(request: &ProbeRequest) -> Result<(), ProbeError> {
 
     if let Some(flags) = &request.trippy_flags {
         let parsed = parse_passthrough_flags(flags)?;
-        let conflicting = [
-            "--tui-latency-warn-threshold",
-            "--tui-latency-bad-threshold",
-            "--tui-loss-warn-threshold",
-            "--tui-loss-bad-threshold",
-            "--tui-row-coloring",
-            "--tui-hop-trend",
-            "--tui-summary-jitter",
-            "--tui-summary-percentiles",
-        ];
-
-        if request.ui_mode == UiMode::Enhanced
-            && parsed
-                .iter()
-                .any(|token| conflicting.iter().any(|flag| token == flag))
-        {
-            return Err(ProbeError::InvalidOption(
-                "--trippy-flags cannot override windows-mtr enhanced UI wrapper settings"
-                    .to_string(),
-            ));
-        }
-
         if request.ui_mode == UiMode::Dashboard
             && parsed
                 .iter()
@@ -428,28 +412,6 @@ pub fn build_embedded_trippy_args(
 
     if let Some(ttl) = request.dns_cache_ttl_seconds {
         trippy_args.extend(["--dns-ttl".to_string(), format!("{ttl}s")]);
-    }
-
-    if request.ui_mode == UiMode::Enhanced {
-        let ui = request.enhanced_ui;
-        trippy_args.extend([
-            "--tui-latency-warn-threshold".to_string(),
-            format!("{}ms", ui.latency_warn_ms),
-            "--tui-latency-bad-threshold".to_string(),
-            format!("{}ms", ui.latency_bad_ms),
-            "--tui-loss-warn-threshold".to_string(),
-            ui.loss_warn_pct.to_string(),
-            "--tui-loss-bad-threshold".to_string(),
-            ui.loss_bad_pct.to_string(),
-            "--tui-row-coloring".to_string(),
-            ui.row_coloring.to_string(),
-            "--tui-hop-trend".to_string(),
-            ui.sparklines.to_string(),
-            "--tui-summary-jitter".to_string(),
-            ui.summary.to_string(),
-            "--tui-summary-percentiles".to_string(),
-            ui.summary.to_string(),
-        ]);
     }
 
     if let Some(extra) = &request.trippy_flags {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -51,26 +51,16 @@ fn test_enhanced_ui_conflicts_with_report_mode() {
 }
 
 #[test]
-fn test_enhanced_wrapper_conflicts_with_passthrough_override() {
+fn test_enhanced_ui_returns_unavailable_error() {
     let output = Command::new("cargo")
-        .args([
-            "run",
-            "--",
-            "--ui",
-            "enhanced",
-            "--trippy-flags",
-            "--tui-summary-percentiles false",
-            "8.8.8.8",
-        ])
+        .args(["run", "--", "--ui", "enhanced", "8.8.8.8"])
         .output()
         .expect("Failed to execute command");
 
     assert!(!output.status.success());
 
     let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
-    assert!(
-        stderr.contains("--trippy-flags cannot override windows-mtr enhanced UI wrapper settings")
-    );
+    assert!(stderr.contains("enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback"));
 }
 
 #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -221,3 +221,33 @@ fn enhanced_ui_overrides_require_enhanced_mode() {
         Err(ProbeError::InvalidOption(_))
     ));
 }
+
+#[test]
+fn enhanced_mode_is_soft_disabled() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Enhanced;
+    let err = build_probe_plan(&request).expect_err("enhanced should be unavailable");
+    assert!(matches!(err, ProbeError::InvalidOption(_)));
+    assert!(
+        err.to_string()
+            .contains("enhanced UI is not available with bundled Trippy 0.13.0")
+    );
+}
+
+#[test]
+fn enhanced_mode_build_args_does_not_emit_unsupported_tui_flags() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Enhanced;
+    let args = build_embedded_trippy_args(&request, "8.8.8.8").expect("args build");
+    let banned = [
+        "--tui-latency-warn-threshold",
+        "--tui-latency-bad-threshold",
+        "--tui-loss-warn-threshold",
+        "--tui-loss-bad-threshold",
+        "--tui-row-coloring",
+        "--tui-hop-trend",
+        "--tui-summary-jitter",
+        "--tui-summary-percentiles",
+    ];
+    assert!(!args.iter().any(|a| banned.contains(&a.as_str())));
+}


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes when the wrapper injects Trippy `--tui-*` flags that are unsupported by the bundled `trippy`/`trippy-tui` 0.13.0. 
- Preserve the embedded Trippy TUI as the recommended/default interactive experience and treat the custom dashboard as an emergency fallback. 
- Make CLI help, UI wording, tests, and docs honest about the current limitations so users are not guided into a broken `--ui enhanced` workflow.

### Description
- Soft-disabled `--ui enhanced` during option validation by returning a clear actionable error: `enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback` in `src/service/mod.rs` so enhanced no longer reaches runtime. 
- Removed injection of unsupported enhanced Trippy flags (the `--tui-*` block) from `build_embedded_trippy_args()` so no unsupported flags are emitted. 
- Reworded CLI help and `TraceCli`/`UiPreset` UX text in `src/main.rs` to mark `enhanced` as unavailable and to present `dashboard` (alias `native`) as a fallback-only mode. 
- Updated dashboard UI in `src/native_ui.rs` to label the UI as `windows-mtr fallback dashboard (...)` and to show a help/footer string that explicitly states the dashboard is JSON-snapshot polling with limited fields and recommends default mode for full interactive UI. 
- Added/updated regression tests that assert `--ui enhanced` validation behavior, verify `build_embedded_trippy_args()` does not emit banned `--tui-*` flags, and check the fallback dashboard wording; tests in `tests/unit_tests.rs`, `tests/cli_tests.rs`, and `src/native_ui.rs` were updated accordingly. 
- Updated `README.md`, `USAGE.md`, and `CHANGELOG.md` to recommend the default `mtr <target>` for the primary interactive experience and to document the dashboard as an experimental fallback and the bugfix.

### Testing
- Ran formatting and lint checks: `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings`, both completed successfully. 
- Ran the full test suite: `cargo test --all`, and all unit/integration/doc tests completed successfully. 
- All updated/added tests that cover enhanced unavailability, banned flag emission, and dashboard wording passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d7b35adc833085f219aecbb0692f)