### PR TITLE
Soft-disable unavailable enhanced UI and relabel dashboard as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Updated documentation and roadmap to reflect delivered v2.0 capabilities.
 
 ### Fixed
+- Stopped passing unsupported enhanced TUI flags to bundled Trippy 0.13.0.
+- Soft-disabled `--ui enhanced` with a clear actionable error recommending default UI or `--ui dashboard` fallback.
+- Clarified fallback dashboard messaging in UI/docs to avoid claiming parity with the embedded Trippy TUI.
 - Hardened security workflow with a pinned Rust toolchain, explicit `cargo-deny` policy file, and an always-on GitHub Actions job summary.
 - Tuned `cargo-deny` policy to handle known transitive advisories and unavoidable duplicate crates in the Trippy 0.13 dependency graph.
 - Added `cargo-audit` policy configuration with documented temporary ignores for transitive upstream advisories in the current Trippy 0.13 stack.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ mtr 8.8.8.8
 mtr --ui dashboard 8.8.8.8
 ```
 
+This dashboard is a fallback path that polls JSON snapshots and exposes limited fields. For the full interactive experience, use the default embedded Trippy TUI with:
+
+```bash
+mtr 8.8.8.8
+```
+
 ### Report mode with DNS disabled (faster + script-friendly)
 
 ```bash

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,7 +34,7 @@ mtr [options] <hostname-or-ip>
 | `-n` | Disable reverse DNS rendering (show IP only) |
 | `-b, --show-asn` | Enable ASN lookup/rendering |
 | `-z` | DNS ASN lookup shortcut |
-| `--ui <default\|enhanced\|dashboard>` | Interactive UI preset (enhanced enables diagnostic overlays) |
+| `--ui <default\|enhanced\|dashboard>` | Interactive UI preset (`enhanced` is temporarily unavailable with bundled Trippy 0.13.0) |
 
 ## Dashboard UI (experimental fallback)
 
@@ -69,15 +69,9 @@ For stable diagnostics, use report mode:
 .\mtr.exe -n -r -c 5 8.8.8.8
 ```
 
-## Enhanced UI options
+## Enhanced UI options (temporarily unavailable)
 
-The `enhanced` preset applies defaults tuned for quicker incident triage:
-
-- Latency color bands: `--latency-warn-ms 100`, `--latency-bad-ms 250`
-- Loss color bands: `--loss-warn-pct 2`, `--loss-bad-pct 5`
-- Row coloring: `--enhanced-row-color on`
-- Per-hop trend/sparkline column: `--enhanced-sparklines on`
-- Percentile + jitter summary area: `--enhanced-summary on`
+`--ui enhanced` is currently soft-disabled with bundled Trippy 0.13.0 and returns an actionable error. Use default UI (`mtr <target>`) for full embedded Trippy TUI, or `--ui dashboard` as an emergency fallback.
 
 | Option | Description |
 |---|---|
@@ -126,11 +120,8 @@ The `enhanced` preset applies defaults tuned for quicker incident triage:
 # Interactive TUI
 mtr 8.8.8.8
 
-# Interactive TUI (enhanced diagnostic preset)
+# Enhanced UI is currently unavailable with bundled Trippy 0.13.0
 mtr --ui enhanced 8.8.8.8
-
-# Enhanced mode with custom threshold bands + toggles
-mtr --ui enhanced --latency-warn-ms 80 --latency-bad-ms 180 --loss-warn-pct 1 --loss-bad-pct 3 --enhanced-sparklines off 8.8.8.8
 
 # TCP report
 mtr -T -P 443 -c 15 -r github.com
@@ -145,14 +136,13 @@ mtr -S 192.0.2.10 -s 128 8.8.4.4
 mtr --trippy-flags "--log-format json --verbose --tui-refresh-rate 150ms" 8.8.8.8
 ```
 
-## Default vs enhanced mode (side-by-side)
+## Default UI vs fallback dashboard
 
-| Default mode | Enhanced mode |
+| Default mode (recommended) | Fallback dashboard |
 |---|---|
-| `mtr 8.8.8.8` | `mtr --ui enhanced 8.8.8.8` |
-| Standard hop table | Adds threshold-based row coloring |
-| Average-focused quick view | Adds percentile + jitter summary |
-| No explicit trend column | Optional per-hop sparkline trend column |
+| `mtr 8.8.8.8` | `mtr --ui dashboard 8.8.8.8` |
+| Full embedded Trippy interactive TUI | JSON snapshot polling with limited fields |
+| Best interactive fidelity | Emergency fallback when embedded TUI crashes |
 
 ![Default mode demo](assets/windows-mtr-m.gif)
 ![Enhanced mode demo](assets/windows-mtr-upscaled.gif)

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ const EMBEDDED_TRIPPY_ENV: &str = "WINDOWS_MTR_EMBEDDED_TRIPPY";
   windows-mtr --json -c 20 example.com          # JSON report output
   windows-mtr --api                              # Run REST API runtime
   windows-mtr --trippy-flags '--tui-refresh-rate 150ms' example.com
-  windows-mtr --ui dashboard 8.8.8.8          # Experimental dashboard fallback (alias: --ui native)")]
+  windows-mtr --ui dashboard 8.8.8.8            # Experimental fallback dashboard (alias: --ui native)")]
 struct Cli {
     /// Run in REST API mode instead of probe CLI mode
     #[arg(long = "api")]
@@ -171,7 +171,7 @@ struct TraceCli {
     )]
     trippy_flags: Option<String>,
 
-    /// UI preset for interactive mode (`dashboard` is an experimental fallback; `native` is a deprecated alias)
+    /// UI preset for interactive mode (`enhanced` is temporarily unavailable with bundled Trippy 0.13.0; `dashboard` is an experimental fallback; `native` is a deprecated alias)
     #[arg(long = "ui", value_enum, default_value_t = UiPreset::Default)]
     ui: UiPreset,
 
@@ -207,6 +207,9 @@ struct TraceCli {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 enum UiPreset {
     Default,
+    #[value(
+        help = "temporarily unavailable with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback"
+    )]
     Enhanced,
     #[value(
         alias = "native",

--- a/src/native_ui.rs
+++ b/src/native_ui.rs
@@ -354,7 +354,7 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
     let tabs = Tabs::new(titles)
         .block(
             Block::default()
-                .title(format!("windows-mtr dashboard ({})", app.target))
+                .title(format!("windows-mtr fallback dashboard ({})", app.target))
                 .borders(Borders::ALL),
         )
         .select(app.tab_index)
@@ -380,7 +380,7 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
 }
 
 fn build_help_text(app: &NativeUiApp) -> String {
-    let base = "Controls: ←/→ or Tab switch tabs • q quits";
+    let base = "Fallback dashboard: JSON snapshot polling, limited fields. For full UI use default mode. Controls: ←/→ or Tab switch tabs • q quits";
     let mut notes = Vec::new();
 
     if app.hops.is_empty() {
@@ -659,7 +659,7 @@ mod tests {
 
         assert_eq!(
             build_help_text(&app),
-            "Controls: ←/→ or Tab switch tabs • q quits"
+            "Fallback dashboard: JSON snapshot polling, limited fields. For full UI use default mode. Controls: ←/→ or Tab switch tabs • q quits"
         );
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -133,42 +133,13 @@ pub fn verify_options(request: &ProbeRequest) -> Result<(), ProbeError> {
     }
 
     if request.ui_mode == UiMode::Enhanced {
-        if request.enhanced_ui.latency_warn_ms >= request.enhanced_ui.latency_bad_ms {
-            return Err(ProbeError::InvalidOption(
-                "--latency-warn-ms must be lower than --latency-bad-ms".to_string(),
-            ));
-        }
-        if request.enhanced_ui.loss_warn_pct >= request.enhanced_ui.loss_bad_pct {
-            return Err(ProbeError::InvalidOption(
-                "--loss-warn-pct must be lower than --loss-bad-pct".to_string(),
-            ));
-        }
+        return Err(ProbeError::InvalidOption(
+            "enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback".to_string(),
+        ));
     }
 
     if let Some(flags) = &request.trippy_flags {
         let parsed = parse_passthrough_flags(flags)?;
-        let conflicting = [
-            "--tui-latency-warn-threshold",
-            "--tui-latency-bad-threshold",
-            "--tui-loss-warn-threshold",
-            "--tui-loss-bad-threshold",
-            "--tui-row-coloring",
-            "--tui-hop-trend",
-            "--tui-summary-jitter",
-            "--tui-summary-percentiles",
-        ];
-
-        if request.ui_mode == UiMode::Enhanced
-            && parsed
-                .iter()
-                .any(|token| conflicting.iter().any(|flag| token == flag))
-        {
-            return Err(ProbeError::InvalidOption(
-                "--trippy-flags cannot override windows-mtr enhanced UI wrapper settings"
-                    .to_string(),
-            ));
-        }
-
         if request.ui_mode == UiMode::Dashboard
             && parsed
                 .iter()
@@ -428,28 +399,6 @@ pub fn build_embedded_trippy_args(
 
     if let Some(ttl) = request.dns_cache_ttl_seconds {
         trippy_args.extend(["--dns-ttl".to_string(), format!("{ttl}s")]);
-    }
-
-    if request.ui_mode == UiMode::Enhanced {
-        let ui = request.enhanced_ui;
-        trippy_args.extend([
-            "--tui-latency-warn-threshold".to_string(),
-            format!("{}ms", ui.latency_warn_ms),
-            "--tui-latency-bad-threshold".to_string(),
-            format!("{}ms", ui.latency_bad_ms),
-            "--tui-loss-warn-threshold".to_string(),
-            ui.loss_warn_pct.to_string(),
-            "--tui-loss-bad-threshold".to_string(),
-            ui.loss_bad_pct.to_string(),
-            "--tui-row-coloring".to_string(),
-            ui.row_coloring.to_string(),
-            "--tui-hop-trend".to_string(),
-            ui.sparklines.to_string(),
-            "--tui-summary-jitter".to_string(),
-            ui.summary.to_string(),
-            "--tui-summary-percentiles".to_string(),
-            ui.summary.to_string(),
-        ]);
     }
 
     if let Some(extra) = &request.trippy_flags {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -51,26 +51,16 @@ fn test_enhanced_ui_conflicts_with_report_mode() {
 }
 
 #[test]
-fn test_enhanced_wrapper_conflicts_with_passthrough_override() {
+fn test_enhanced_ui_returns_clean_unavailable_error() {
     let output = Command::new("cargo")
-        .args([
-            "run",
-            "--",
-            "--ui",
-            "enhanced",
-            "--trippy-flags",
-            "--tui-summary-percentiles false",
-            "8.8.8.8",
-        ])
+        .args(["run", "--", "--ui", "enhanced", "8.8.8.8"])
         .output()
         .expect("Failed to execute command");
 
     assert!(!output.status.success());
 
     let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
-    assert!(
-        stderr.contains("--trippy-flags cannot override windows-mtr enhanced UI wrapper settings")
-    );
+    assert!(stderr.contains("enhanced UI is not available with bundled Trippy 0.13.0"));
 }
 
 #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -221,3 +221,28 @@ fn enhanced_ui_overrides_require_enhanced_mode() {
         Err(ProbeError::InvalidOption(_))
     ));
 }
+
+#[test]
+fn build_embedded_trippy_args_enhanced_mode_does_not_emit_unsupported_tui_flags() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Enhanced;
+
+    let args = build_embedded_trippy_args(&request, "8.8.8.8").expect("should build");
+    let unsupported = [
+        "--tui-latency-warn-threshold",
+        "--tui-latency-bad-threshold",
+        "--tui-loss-warn-threshold",
+        "--tui-loss-bad-threshold",
+        "--tui-row-coloring",
+        "--tui-hop-trend",
+        "--tui-summary-jitter",
+        "--tui-summary-percentiles",
+    ];
+
+    for flag in unsupported {
+        assert!(
+            !args.iter().any(|token| token == flag),
+            "unexpected unsupported trippy flag present: {flag}"
+        );
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent runtime failures when the bundled Trippy 0.13.0 rejects unsupported `--tui-*` flags by ensuring the wrapper never injects them. 
- Keep the default interactive UI as the real embedded Trippy TUI and treat the JSON-polling dashboard as an emergency fallback only. 
- Provide a clear, actionable error for `--ui enhanced` rather than silently forwarding unsupported flags. 

### Description

- Soft-disable the enhanced preset in `verify_options` so `UiMode::Enhanced` returns an actionable validation error: "enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback" (change in `src/service/mod.rs`).
- Remove injection of unsupported `--tui-*` enhanced flags from `build_embedded_trippy_args`, so embedded Trippy args no longer include those flags (change in `src/service/mod.rs`).
- Update CLI help/value metadata to mark `enhanced` temporarily unavailable and clarify `dashboard`/`native` as the experimental fallback (change in `src/main.rs`).
- Relabel dashboard UI text and help/footer to explicitly indicate it is a "fallback dashboard" using JSON snapshot polling with limited fields (change in `src/native_ui.rs`).
- Add/adjust tests to cover the change: unit test ensuring enhanced mode does not emit unsupported `--tui-*` flags and CLI tests asserting `--ui enhanced` yields the clean unavailable error; update README/USAGE/CHANGELOG messaging accordingly.

### Testing

- Ran formatting check with `cargo fmt --all -- --check` and it succeeded. 
- Ran linting with `cargo clippy --all-targets -- -D warnings` and it succeeded. 
- Ran the full test suite with `cargo test --all` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d7b35adc833085f219aecbb0692f)