### PR TITLE
Soft-disable `--ui enhanced`, stop emitting unsupported Trippy `--tui-*` flags, and mark dashboard as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added an experimental dashboard preview mode via `--ui dashboard` (deprecated compatibility alias: `--ui native`) with tabs, hop table rendering, and live latency/loss charts.
 
 ### Changed
-- Updated README/USAGE roadmap and examples to document the dashboard fallback UI and controls.
-- Improved the dashboard UI help footer to show elapsed "awaiting data" time and add a 15-second timeout troubleshooting prompt when hop snapshots never arrive.
+- Updated README/USAGE to keep the default embedded Trippy TUI as the primary recommended interactive experience and to document dashboard mode as an experimental fallback only.
+- Clarified CLI behavior for `--ui enhanced`: unavailable with bundled Trippy 0.13.0 and now returns a clean actionable validation error.
+- Improved the fallback dashboard title/help footer wording to clearly communicate JSON polling limitations and default-mode recommendation.
+
+### Fixed
+- Stopped passing unsupported enhanced `--tui-*` flags to bundled Trippy 0.13.0 (`--tui-latency-*`, `--tui-loss-*`, `--tui-row-coloring`, `--tui-hop-trend`, `--tui-summary-*`).
 
 ## [1.1.3] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ mtr 8.8.8.8
 > [!TIP]
 > From the canonical ZIP, use `.\mtr.exe` or `.\windows-mtr.exe` directly.
 
-### Dashboard fallback UI (experimental)
+### Dashboard fallback UI (experimental, limited)
 
 ```bash
 mtr --ui dashboard 8.8.8.8
@@ -213,7 +213,7 @@ mtr -n -r -c 20 1.1.1.1
 
 ### Troubleshooting
 
-If interactive TUI crashes (for example Windows status `0xC0000005`), try:
+If embedded Trippy interactive TUI crashes (for example Windows status `0xC0000005`), try the fallback dashboard:
 
 ```bash
 .\mtr.exe --ui dashboard 8.8.8.8

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,7 +34,7 @@ mtr [options] <hostname-or-ip>
 | `-n` | Disable reverse DNS rendering (show IP only) |
 | `-b, --show-asn` | Enable ASN lookup/rendering |
 | `-z` | DNS ASN lookup shortcut |
-| `--ui <default\|enhanced\|dashboard>` | Interactive UI preset (enhanced enables diagnostic overlays) |
+| `--ui <default|enhanced|dashboard>` | Interactive UI preset (`default` = full embedded Trippy TUI, `dashboard` = experimental fallback, `enhanced` currently unavailable with bundled Trippy 0.13.0) |
 
 ## Dashboard UI (experimental fallback)
 
@@ -69,9 +69,11 @@ For stable diagnostics, use report mode:
 .\mtr.exe -n -r -c 5 8.8.8.8
 ```
 
-## Enhanced UI options
+## Enhanced UI options (currently unavailable with bundled Trippy 0.13.0)
 
-The `enhanced` preset applies defaults tuned for quicker incident triage:
+`--ui enhanced` is currently soft-disabled because bundled Trippy 0.13.0 does not support the required enhanced `--tui-*` flags. Use default interactive mode (`mtr 8.8.8.8`) or fallback dashboard mode (`mtr --ui dashboard 8.8.8.8`).
+
+When enhanced becomes supported again, the preset is intended to apply defaults tuned for quicker incident triage:
 
 - Latency color bands: `--latency-warn-ms 100`, `--latency-bad-ms 250`
 - Loss color bands: `--loss-warn-pct 2`, `--loss-bad-pct 5`
@@ -126,12 +128,8 @@ The `enhanced` preset applies defaults tuned for quicker incident triage:
 # Interactive TUI
 mtr 8.8.8.8
 
-# Interactive TUI (enhanced diagnostic preset)
-mtr --ui enhanced 8.8.8.8
-
-# Enhanced mode with custom threshold bands + toggles
-mtr --ui enhanced --latency-warn-ms 80 --latency-bad-ms 180 --loss-warn-pct 1 --loss-bad-pct 3 --enhanced-sparklines off 8.8.8.8
-
+# NOTE: --ui enhanced is currently unavailable with bundled Trippy 0.13.0
+# mtr --ui enhanced 8.8.8.8
 # TCP report
 mtr -T -P 443 -c 15 -r github.com
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,31 +175,31 @@ struct TraceCli {
     #[arg(long = "ui", value_enum, default_value_t = UiPreset::Default)]
     ui: UiPreset,
 
-    /// Latency warning threshold in milliseconds for enhanced UI coloring
+    /// Latency warning threshold in milliseconds for enhanced UI coloring (currently unavailable with bundled Trippy 0.13.0)
     #[arg(long = "latency-warn-ms", value_name = "MS")]
     latency_warn_ms: Option<f32>,
 
-    /// Latency critical threshold in milliseconds for enhanced UI coloring
+    /// Latency critical threshold in milliseconds for enhanced UI coloring (currently unavailable with bundled Trippy 0.13.0)
     #[arg(long = "latency-bad-ms", value_name = "MS")]
     latency_bad_ms: Option<f32>,
 
-    /// Packet loss warning threshold percentage for enhanced UI coloring
+    /// Packet loss warning threshold percentage for enhanced UI coloring (currently unavailable with bundled Trippy 0.13.0)
     #[arg(long = "loss-warn-pct", value_name = "PCT")]
     loss_warn_pct: Option<f32>,
 
-    /// Packet loss critical threshold percentage for enhanced UI coloring
+    /// Packet loss critical threshold percentage for enhanced UI coloring (currently unavailable with bundled Trippy 0.13.0)
     #[arg(long = "loss-bad-pct", value_name = "PCT")]
     loss_bad_pct: Option<f32>,
 
-    /// Toggle row coloring bands in enhanced UI
+    /// Toggle row coloring bands in enhanced UI (currently unavailable with bundled Trippy 0.13.0)
     #[arg(long = "enhanced-row-color", value_enum, value_name = "on|off")]
     enhanced_row_color: Option<OnOff>,
 
-    /// Toggle per-hop trend/sparkline column in enhanced UI
+    /// Toggle per-hop trend/sparkline column in enhanced UI (currently unavailable with bundled Trippy 0.13.0)
     #[arg(long = "enhanced-sparklines", value_enum, value_name = "on|off")]
     enhanced_sparklines: Option<OnOff>,
 
-    /// Toggle percentile/jitter summary in enhanced UI
+    /// Toggle percentile/jitter summary in enhanced UI (currently unavailable with bundled Trippy 0.13.0)
     #[arg(long = "enhanced-summary", value_enum, value_name = "on|off")]
     enhanced_summary: Option<OnOff>,
 }
@@ -207,6 +207,7 @@ struct TraceCli {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 enum UiPreset {
     Default,
+    #[value(help = "unavailable with bundled Trippy 0.13.0; returns a validation error")]
     Enhanced,
     #[value(
         alias = "native",

--- a/src/native_ui.rs
+++ b/src/native_ui.rs
@@ -354,7 +354,7 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
     let tabs = Tabs::new(titles)
         .block(
             Block::default()
-                .title(format!("windows-mtr dashboard ({})", app.target))
+                .title(dashboard_title(&app.target))
                 .borders(Borders::ALL),
         )
         .select(app.tab_index)
@@ -379,8 +379,12 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
     frame.render_widget(help, chunks[2]);
 }
 
+fn dashboard_title(target: &str) -> String {
+    format!("windows-mtr fallback dashboard ({target})")
+}
+
 fn build_help_text(app: &NativeUiApp) -> String {
-    let base = "Controls: ←/→ or Tab switch tabs • q quits";
+    let base = "Fallback dashboard: JSON snapshot polling, limited fields. For full UI use default mode. • Controls: ←/→ or Tab switch tabs • q quits";
     let mut notes = Vec::new();
 
     if app.hops.is_empty() {
@@ -659,7 +663,7 @@ mod tests {
 
         assert_eq!(
             build_help_text(&app),
-            "Controls: ←/→ or Tab switch tabs • q quits"
+            "Fallback dashboard: JSON snapshot polling, limited fields. For full UI use default mode. • Controls: ←/→ or Tab switch tabs • q quits"
         );
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -133,42 +133,13 @@ pub fn verify_options(request: &ProbeRequest) -> Result<(), ProbeError> {
     }
 
     if request.ui_mode == UiMode::Enhanced {
-        if request.enhanced_ui.latency_warn_ms >= request.enhanced_ui.latency_bad_ms {
-            return Err(ProbeError::InvalidOption(
-                "--latency-warn-ms must be lower than --latency-bad-ms".to_string(),
-            ));
-        }
-        if request.enhanced_ui.loss_warn_pct >= request.enhanced_ui.loss_bad_pct {
-            return Err(ProbeError::InvalidOption(
-                "--loss-warn-pct must be lower than --loss-bad-pct".to_string(),
-            ));
-        }
+        return Err(ProbeError::InvalidOption(
+            "enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback".to_string(),
+        ));
     }
 
     if let Some(flags) = &request.trippy_flags {
         let parsed = parse_passthrough_flags(flags)?;
-        let conflicting = [
-            "--tui-latency-warn-threshold",
-            "--tui-latency-bad-threshold",
-            "--tui-loss-warn-threshold",
-            "--tui-loss-bad-threshold",
-            "--tui-row-coloring",
-            "--tui-hop-trend",
-            "--tui-summary-jitter",
-            "--tui-summary-percentiles",
-        ];
-
-        if request.ui_mode == UiMode::Enhanced
-            && parsed
-                .iter()
-                .any(|token| conflicting.iter().any(|flag| token == flag))
-        {
-            return Err(ProbeError::InvalidOption(
-                "--trippy-flags cannot override windows-mtr enhanced UI wrapper settings"
-                    .to_string(),
-            ));
-        }
-
         if request.ui_mode == UiMode::Dashboard
             && parsed
                 .iter()
@@ -428,28 +399,6 @@ pub fn build_embedded_trippy_args(
 
     if let Some(ttl) = request.dns_cache_ttl_seconds {
         trippy_args.extend(["--dns-ttl".to_string(), format!("{ttl}s")]);
-    }
-
-    if request.ui_mode == UiMode::Enhanced {
-        let ui = request.enhanced_ui;
-        trippy_args.extend([
-            "--tui-latency-warn-threshold".to_string(),
-            format!("{}ms", ui.latency_warn_ms),
-            "--tui-latency-bad-threshold".to_string(),
-            format!("{}ms", ui.latency_bad_ms),
-            "--tui-loss-warn-threshold".to_string(),
-            ui.loss_warn_pct.to_string(),
-            "--tui-loss-bad-threshold".to_string(),
-            ui.loss_bad_pct.to_string(),
-            "--tui-row-coloring".to_string(),
-            ui.row_coloring.to_string(),
-            "--tui-hop-trend".to_string(),
-            ui.sparklines.to_string(),
-            "--tui-summary-jitter".to_string(),
-            ui.summary.to_string(),
-            "--tui-summary-percentiles".to_string(),
-            ui.summary.to_string(),
-        ]);
     }
 
     if let Some(extra) = &request.trippy_flags {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -51,7 +51,7 @@ fn test_enhanced_ui_conflicts_with_report_mode() {
 }
 
 #[test]
-fn test_enhanced_wrapper_conflicts_with_passthrough_override() {
+fn test_enhanced_ui_returns_unavailable_error_even_with_passthrough() {
     let output = Command::new("cargo")
         .args([
             "run",
@@ -68,9 +68,7 @@ fn test_enhanced_wrapper_conflicts_with_passthrough_override() {
     assert!(!output.status.success());
 
     let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
-    assert!(
-        stderr.contains("--trippy-flags cannot override windows-mtr enhanced UI wrapper settings")
-    );
+    assert!(stderr.contains("enhanced UI is not available with bundled Trippy 0.13.0"));
 }
 
 #[test]
@@ -156,4 +154,17 @@ fn test_basic_execution() {
     // Check for expected output format in report mode
     assert!(stdout.contains("Host"));
     assert!(stdout.contains("Loss%"));
+}
+
+#[test]
+fn test_enhanced_ui_is_soft_disabled_in_interactive_mode() {
+    let output = Command::new("cargo")
+        .args(["run", "--", "--ui", "enhanced", "8.8.8.8"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
+    assert!(stderr.contains("enhanced UI is not available with bundled Trippy 0.13.0"));
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -221,3 +221,38 @@ fn enhanced_ui_overrides_require_enhanced_mode() {
         Err(ProbeError::InvalidOption(_))
     ));
 }
+
+#[test]
+fn enhanced_mode_embedded_args_do_not_include_unsupported_tui_flags() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Enhanced;
+
+    let args = build_embedded_trippy_args(&request, "8.8.8.8").expect("should build");
+
+    assert!(!args.iter().any(|t| {
+        matches!(
+            t.as_str(),
+            "--tui-latency-warn-threshold"
+                | "--tui-latency-bad-threshold"
+                | "--tui-loss-warn-threshold"
+                | "--tui-loss-bad-threshold"
+                | "--tui-row-coloring"
+                | "--tui-hop-trend"
+                | "--tui-summary-jitter"
+                | "--tui-summary-percentiles"
+        )
+    }));
+}
+
+#[test]
+fn enhanced_mode_returns_validation_error() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Enhanced;
+
+    let err = build_probe_plan(&request).expect_err("enhanced mode should be unavailable");
+    assert!(matches!(err, ProbeError::InvalidOption(_)));
+    assert!(
+        err.to_string()
+            .contains("enhanced UI is not available with bundled Trippy 0.13.0")
+    );
+}


### PR DESCRIPTION
### Motivation
- Embedded Trippy 0.13.0 does not accept the enhanced `--tui-*` tuning flags, which caused runtime failures when `--ui enhanced` was used.  
- The custom dashboard is a lower-fidelity JSON-polling fallback and must be clearly communicated as such, not promoted as a native replacement for the embedded Trippy TUI.  
- Prevent the wrapper from passing unsupported flags to bundled Trippy and give users an actionable, clear validation error for `--ui enhanced` until the feature is supported upstream.  

### Description
- Soft-disable the enhanced preset at validation time by returning `ProbeError::InvalidOption` with message: `"enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback"` in `src/service/mod.rs` instead of injecting unsupported flags.  
- Remove injection of unsupported `--tui-*` flags from `build_embedded_trippy_args()` so no unsupported `--tui-latency-*`, `--tui-loss-*`, `--tui-row-coloring`, `--tui-hop-trend`, or `--tui-summary-*` flags are emitted.  
- Update CLI/help text in `src/main.rs` so `UiPreset::Enhanced` is marked unavailable with bundled Trippy and leave `--ui dashboard` (and `--ui native` alias) as the experimental fallback.  
- Relabel and reword the dashboard UI in `src/native_ui.rs` to `windows-mtr fallback dashboard (...)` and update the help/footer text to explicitly state it is JSON snapshot polling with limited fields and recommend the default mode for full UI fidelity.  
- Add and update regression tests in `tests/unit_tests.rs` and `tests/cli_tests.rs` to assert that `build_embedded_trippy_args()` for `UiMode::Enhanced` does not contain unsupported `--tui-*` tokens and that `--ui enhanced` produces the new validation error; update CLI/docs (`USAGE.md`, `README.md`, `CHANGELOG.md`) to document `enhanced` as unavailable and `dashboard` as an experimental fallback.  

### Testing
- Ran `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` and both succeeded.  
- Ran `cargo test --all` and the full test suite passed (unit, CLI, API contract, and integration tests including the new regression tests).  
- New tests added: `enhanced_mode_embedded_args_do_not_include_unsupported_tui_flags`, `enhanced_mode_returns_validation_error`, and `test_enhanced_ui_is_soft_disabled_in_interactive_mode`, which all passed as part of the CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d7b35adc833085f219aecbb0692f)