### PR TITLE
Soft‑disable enhanced UI, stop emitting unsupported Trippy --tui-* flags, and mark dashboard as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Updated documentation and roadmap to reflect delivered v2.0 capabilities.
 
 ### Fixed
+- Fixed `--ui enhanced` handling for bundled Trippy 0.13.0: stop passing unsupported `--tui-*` flags and return a clear unavailable-with-action message.
+- Clarified `--ui dashboard` as an experimental fallback dashboard (JSON snapshot polling, limited fields), not parity with the embedded Trippy TUI.
 - Hardened security workflow with a pinned Rust toolchain, explicit `cargo-deny` policy file, and an always-on GitHub Actions job summary.
 - Tuned `cargo-deny` policy to handle known transitive advisories and unavoidable duplicate crates in the Trippy 0.13 dependency graph.
 - Added `cargo-audit` policy configuration with documented temporary ignores for transitive upstream advisories in the current Trippy 0.13 stack.

--- a/README.md
+++ b/README.md
@@ -199,11 +199,13 @@ mtr 8.8.8.8
 > [!TIP]
 > From the canonical ZIP, use `.\mtr.exe` or `.\windows-mtr.exe` directly.
 
-### Dashboard fallback UI (experimental)
+### Dashboard fallback UI (experimental, limited)
 
 ```bash
 mtr --ui dashboard 8.8.8.8
 ```
+
+`--ui enhanced` is currently unavailable with bundled Trippy 0.13.0. Use default mode (`mtr 8.8.8.8`) for the full embedded Trippy TUI.
 
 ### Report mode with DNS disabled (faster + script-friendly)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,7 +34,7 @@ mtr [options] <hostname-or-ip>
 | `-n` | Disable reverse DNS rendering (show IP only) |
 | `-b, --show-asn` | Enable ASN lookup/rendering |
 | `-z` | DNS ASN lookup shortcut |
-| `--ui <default\|enhanced\|dashboard>` | Interactive UI preset (enhanced enables diagnostic overlays) |
+| `--ui <default\|enhanced\|dashboard>` | Interactive UI preset (`enhanced` currently unavailable with bundled Trippy 0.13.0) |
 
 ## Dashboard UI (experimental fallback)
 
@@ -71,23 +71,9 @@ For stable diagnostics, use report mode:
 
 ## Enhanced UI options
 
-The `enhanced` preset applies defaults tuned for quicker incident triage:
+`--ui enhanced` is currently unavailable with bundled Trippy 0.13.0. Running enhanced mode now returns a clear validation error that recommends default UI or dashboard fallback.
 
-- Latency color bands: `--latency-warn-ms 100`, `--latency-bad-ms 250`
-- Loss color bands: `--loss-warn-pct 2`, `--loss-bad-pct 5`
-- Row coloring: `--enhanced-row-color on`
-- Per-hop trend/sparkline column: `--enhanced-sparklines on`
-- Percentile + jitter summary area: `--enhanced-summary on`
-
-| Option | Description |
-|---|---|
-| `--latency-warn-ms <MS>` | Warning threshold for per-hop latency coloring |
-| `--latency-bad-ms <MS>` | Critical threshold for per-hop latency coloring |
-| `--loss-warn-pct <PCT>` | Warning threshold for packet loss coloring |
-| `--loss-bad-pct <PCT>` | Critical threshold for packet loss coloring |
-| `--enhanced-row-color <on\|off>` | Enable/disable row band coloring in enhanced mode |
-| `--enhanced-sparklines <on\|off>` | Enable/disable per-hop trend/sparkline column |
-| `--enhanced-summary <on\|off>` | Enable/disable percentile and jitter summary area |
+Enhanced tuning flags are retained for forward compatibility but require future bundled Trippy support before they can be used again.
 
 ## Timing & DNS Cache
 
@@ -126,12 +112,6 @@ The `enhanced` preset applies defaults tuned for quicker incident triage:
 # Interactive TUI
 mtr 8.8.8.8
 
-# Interactive TUI (enhanced diagnostic preset)
-mtr --ui enhanced 8.8.8.8
-
-# Enhanced mode with custom threshold bands + toggles
-mtr --ui enhanced --latency-warn-ms 80 --latency-bad-ms 180 --loss-warn-pct 1 --loss-bad-pct 3 --enhanced-sparklines off 8.8.8.8
-
 # TCP report
 mtr -T -P 443 -c 15 -r github.com
 
@@ -145,17 +125,11 @@ mtr -S 192.0.2.10 -s 128 8.8.4.4
 mtr --trippy-flags "--log-format json --verbose --tui-refresh-rate 150ms" 8.8.8.8
 ```
 
-## Default vs enhanced mode (side-by-side)
+## Interactive mode recommendation
 
-| Default mode | Enhanced mode |
-|---|---|
-| `mtr 8.8.8.8` | `mtr --ui enhanced 8.8.8.8` |
-| Standard hop table | Adds threshold-based row coloring |
-| Average-focused quick view | Adds percentile + jitter summary |
-| No explicit trend column | Optional per-hop sparkline trend column |
+Use `mtr 8.8.8.8` as the primary interactive experience (embedded Trippy TUI).
 
-![Default mode demo](assets/windows-mtr-m.gif)
-![Enhanced mode demo](assets/windows-mtr-upscaled.gif)
+Use `mtr --ui dashboard 8.8.8.8` only as a fallback dashboard for terminals where the embedded TUI crashes.
 
 ## REST API startup and operational limits (v1, implemented)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ struct TraceCli {
     )]
     trippy_flags: Option<String>,
 
-    /// UI preset for interactive mode (`dashboard` is an experimental fallback; `native` is a deprecated alias)
+    /// UI preset for interactive mode (`enhanced` is currently unavailable with bundled Trippy 0.13.0; `dashboard` is an experimental fallback; `native` is a deprecated alias)
     #[arg(long = "ui", value_enum, default_value_t = UiPreset::Default)]
     ui: UiPreset,
 
@@ -207,6 +207,9 @@ struct TraceCli {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
 enum UiPreset {
     Default,
+    #[value(
+        help = "unavailable with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback"
+    )]
     Enhanced,
     #[value(
         alias = "native",

--- a/src/native_ui.rs
+++ b/src/native_ui.rs
@@ -21,6 +21,8 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+const FALLBACK_DASHBOARD_TITLE_PREFIX: &str = "windows-mtr fallback dashboard";
+
 const EMBEDDED_TRIPPY_ENV: &str = "WINDOWS_MTR_EMBEDDED_TRIPPY";
 
 #[derive(Clone)]
@@ -354,7 +356,10 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
     let tabs = Tabs::new(titles)
         .block(
             Block::default()
-                .title(format!("windows-mtr dashboard ({})", app.target))
+                .title(format!(
+                    "{FALLBACK_DASHBOARD_TITLE_PREFIX} ({})",
+                    app.target
+                ))
                 .borders(Borders::ALL),
         )
         .select(app.tab_index)
@@ -380,7 +385,7 @@ fn draw_ui(frame: &mut ratatui::Frame<'_>, app: &NativeUiApp) {
 }
 
 fn build_help_text(app: &NativeUiApp) -> String {
-    let base = "Controls: ←/→ or Tab switch tabs • q quits";
+    let base = "Fallback dashboard: JSON snapshot polling, limited fields. For full UI use default mode. • Controls: ←/→ or Tab switch tabs • q quits";
     let mut notes = Vec::new();
 
     if app.hops.is_empty() {
@@ -659,7 +664,7 @@ mod tests {
 
         assert_eq!(
             build_help_text(&app),
-            "Controls: ←/→ or Tab switch tabs • q quits"
+            "Fallback dashboard: JSON snapshot polling, limited fields. For full UI use default mode. • Controls: ←/→ or Tab switch tabs • q quits"
         );
     }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -133,41 +133,13 @@ pub fn verify_options(request: &ProbeRequest) -> Result<(), ProbeError> {
     }
 
     if request.ui_mode == UiMode::Enhanced {
-        if request.enhanced_ui.latency_warn_ms >= request.enhanced_ui.latency_bad_ms {
-            return Err(ProbeError::InvalidOption(
-                "--latency-warn-ms must be lower than --latency-bad-ms".to_string(),
-            ));
-        }
-        if request.enhanced_ui.loss_warn_pct >= request.enhanced_ui.loss_bad_pct {
-            return Err(ProbeError::InvalidOption(
-                "--loss-warn-pct must be lower than --loss-bad-pct".to_string(),
-            ));
-        }
+        return Err(ProbeError::InvalidOption(
+            "enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback".to_string(),
+        ));
     }
 
     if let Some(flags) = &request.trippy_flags {
         let parsed = parse_passthrough_flags(flags)?;
-        let conflicting = [
-            "--tui-latency-warn-threshold",
-            "--tui-latency-bad-threshold",
-            "--tui-loss-warn-threshold",
-            "--tui-loss-bad-threshold",
-            "--tui-row-coloring",
-            "--tui-hop-trend",
-            "--tui-summary-jitter",
-            "--tui-summary-percentiles",
-        ];
-
-        if request.ui_mode == UiMode::Enhanced
-            && parsed
-                .iter()
-                .any(|token| conflicting.iter().any(|flag| token == flag))
-        {
-            return Err(ProbeError::InvalidOption(
-                "--trippy-flags cannot override windows-mtr enhanced UI wrapper settings"
-                    .to_string(),
-            ));
-        }
 
         if request.ui_mode == UiMode::Dashboard
             && parsed
@@ -428,28 +400,6 @@ pub fn build_embedded_trippy_args(
 
     if let Some(ttl) = request.dns_cache_ttl_seconds {
         trippy_args.extend(["--dns-ttl".to_string(), format!("{ttl}s")]);
-    }
-
-    if request.ui_mode == UiMode::Enhanced {
-        let ui = request.enhanced_ui;
-        trippy_args.extend([
-            "--tui-latency-warn-threshold".to_string(),
-            format!("{}ms", ui.latency_warn_ms),
-            "--tui-latency-bad-threshold".to_string(),
-            format!("{}ms", ui.latency_bad_ms),
-            "--tui-loss-warn-threshold".to_string(),
-            ui.loss_warn_pct.to_string(),
-            "--tui-loss-bad-threshold".to_string(),
-            ui.loss_bad_pct.to_string(),
-            "--tui-row-coloring".to_string(),
-            ui.row_coloring.to_string(),
-            "--tui-hop-trend".to_string(),
-            ui.sparklines.to_string(),
-            "--tui-summary-jitter".to_string(),
-            ui.summary.to_string(),
-            "--tui-summary-percentiles".to_string(),
-            ui.summary.to_string(),
-        ]);
     }
 
     if let Some(extra) = &request.trippy_flags {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -38,39 +38,16 @@ fn test_version_output() {
 }
 
 #[test]
-fn test_enhanced_ui_conflicts_with_report_mode() {
+fn test_enhanced_ui_is_soft_disabled_with_actionable_error() {
     let output = Command::new("cargo")
-        .args(["run", "--", "--ui", "enhanced", "-r", "8.8.8.8"])
+        .args(["run", "--", "--ui", "enhanced", "8.8.8.8"])
         .output()
         .expect("Failed to execute command");
 
     assert!(!output.status.success());
 
     let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
-    assert!(stderr.contains("--ui enhanced is only supported in interactive TUI mode"));
-}
-
-#[test]
-fn test_enhanced_wrapper_conflicts_with_passthrough_override() {
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "--",
-            "--ui",
-            "enhanced",
-            "--trippy-flags",
-            "--tui-summary-percentiles false",
-            "8.8.8.8",
-        ])
-        .output()
-        .expect("Failed to execute command");
-
-    assert!(!output.status.success());
-
-    let stderr = String::from_utf8(output.stderr).expect("Invalid UTF-8");
-    assert!(
-        stderr.contains("--trippy-flags cannot override windows-mtr enhanced UI wrapper settings")
-    );
+    assert!(stderr.contains("enhanced UI is not available with bundled Trippy 0.13.0"));
 }
 
 #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -212,6 +212,37 @@ fn build_json_snapshot_args_rejects_conflicting_passthrough_flags() {
 }
 
 #[test]
+fn enhanced_ui_is_soft_disabled_with_actionable_error() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Enhanced;
+
+    assert!(matches!(
+        build_probe_plan(&request),
+        Err(ProbeError::InvalidOption(msg)) if msg.contains("enhanced UI is not available with bundled Trippy 0.13.0")
+    ));
+}
+
+#[test]
+fn build_embedded_trippy_args_enhanced_has_no_unsupported_tui_flags() {
+    let mut request = base_request();
+    request.ui_mode = UiMode::Enhanced;
+
+    let args = build_embedded_trippy_args(&request, "8.8.8.8").expect("should build");
+    for forbidden in [
+        "--tui-latency-warn-threshold",
+        "--tui-latency-bad-threshold",
+        "--tui-loss-warn-threshold",
+        "--tui-loss-bad-threshold",
+        "--tui-row-coloring",
+        "--tui-hop-trend",
+        "--tui-summary-jitter",
+        "--tui-summary-percentiles",
+    ] {
+        assert!(!args.iter().any(|token| token == forbidden));
+    }
+}
+
+#[test]
 fn enhanced_ui_overrides_require_enhanced_mode() {
     let mut request = base_request();
     request.has_enhanced_overrides = true;


### PR DESCRIPTION
### Motivation
- Fix a runtime crash where the wrapper injected unsupported Trippy 0.13.0 `--tui-*` flags into embedded Trippy when `--ui enhanced` was selected. 
- Ensure the default interactive experience remains the real embedded Trippy TUI and treat the dashboard as an emergency fallback only. 
- Prevent the wrapper from passing unsupported tuning flags unless the bundled Trippy CLI is proven to accept them. 
- Make user-facing docs and help copy honest about `--ui enhanced` and `--ui dashboard` to avoid guiding users into broken flows.

### Description
- Soft-disabled enhanced UI at validation time by returning a clear actionable error for `UiMode::Enhanced`: "enhanced UI is not available with bundled Trippy 0.13.0; use default UI or --ui dashboard fallback" (change in `src/service/mod.rs`).
- Removed automatic injection of enhanced `--tui-*` tuning flags from `build_embedded_trippy_args()` so unsupported flags are never emitted to embedded Trippy (change in `src/service/mod.rs`).
- Removed the enhanced passthrough-conflict logic that assumed wrapper-owned `--tui-*` settings and kept dashboard passthrough conflict checks intact for snapshot mode.
- Updated CLI metadata/help so `UiPreset::Enhanced` is marked unavailable and `--ui dashboard` is explicitly an experimental fallback (change in `src/main.rs`).
- Relabeled dashboard visuals and help text to honest wording (title now `windows-mtr fallback dashboard` and help/footer explains JSON snapshot polling and limitations) in `src/native_ui.rs`.
- Added and updated regression tests to assert the new validation behavior and that no unsupported `--tui-*` tokens are present in generated args; updated CLI tests and unit tests accordingly (changes in `tests/cli_tests.rs` and `tests/unit_tests.rs`).
- Updated documentation (`README.md`, `USAGE.md`) and `CHANGELOG.md` to recommend default `mtr 8.8.8.8`, mark enhanced unavailable, and describe dashboard as a fallback.

### Testing
- Ran `cargo fmt --all -- --check` and it succeeded. 
- Ran `cargo clippy --all-targets -- -D warnings` and it succeeded. 
- Ran `cargo test --all` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d7b35adc833085f219aecbb0692f)