### PR TITLE
ci: add security-audit job (cargo-audit + fuzz smoke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,53 @@ jobs:
           ./scripts/check_openapi_compat.sh "${base_ref}"
 
 
+  security-audit:
+    name: Security audit + fuzz smoke
+    runs-on: ubuntu-latest
+    needs: pre-commit
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@598ce37759ea3902bf8efb433c7b6b0f81d44757 # cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Build fuzz targets
+        run: cargo fuzz build --fuzz-dir fuzz
+
+      - name: Run fuzz targets (smoke)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for target in $(cargo fuzz list --fuzz-dir fuzz); do
+            echo "Running fuzz target: ${target}"
+            set +e
+            timeout 30s cargo fuzz run --fuzz-dir fuzz "${target}" -- -max_total_time=20
+            status=$?
+            set -e
+            if [ "$status" -eq 124 ]; then
+              echo "Target ${target} reached CI timeout (expected for smoke run)."
+              continue
+            fi
+            if [ "$status" -ne 0 ]; then
+              echo "Fuzz target ${target} failed with status ${status}." >&2
+              exit "$status"
+            fi
+          done
+
+
   docker-build-amd64:
     name: Test (docker, linux/amd64)
     runs-on: ubuntu-latest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,6 +100,20 @@ SKIP=hadolint pre-commit run --all-files
 - `xtask/` — automation helpers
 - `docs/` — expanded project documentation
 
+## Security & Fuzzing
+
+- `cargo audit` is enforced in CI and fails builds on known advisories (`warnings`, `unmaintained`, `unsound`, and `yanked`).
+- `cargo fuzz` targets in `fuzz/` are built and smoke-tested in CI to catch crash regressions early.
+- For deeper local campaigns, run: `cargo fuzz run --fuzz-dir fuzz <target>`.
+
+Local security commands:
+
+```bash
+cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
+cargo fuzz build --fuzz-dir fuzz
+cargo fuzz list --fuzz-dir fuzz
+```
+
 ## Troubleshooting
 
 ### Build fails with linker/toolchain errors (Windows)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     <a href="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml/badge.svg"></a>
     <a href="https://github.com/benjisho/windows-mtr/actions/workflows/release.yml"><img alt="Release" src="https://github.com/benjisho/windows-mtr/actions/workflows/release.yml/badge.svg?branch=master"></a>
     <a href="https://github.com/benjisho/windows-mtr/actions/workflows/security.yml"><img alt="Security" src="https://github.com/benjisho/windows-mtr/actions/workflows/security.yml/badge.svg"></a>
+    <a href="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml"><img alt="Security Audit" src="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml/badge.svg?job=security-audit"></a>
     <a href="https://github.com/benjisho/windows-mtr/releases"><img alt="Version" src="https://img.shields.io/github/v/release/benjisho/windows-mtr?color=blue&label=Version"></a>
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-orange.svg"></a>
   </p>
@@ -93,7 +94,7 @@ Windows MTR is built with enterprise-level security practices:
 
 - 🛡️ Regular security audits with automated scanning
 - 🔒 All dependencies vetted for vulnerabilities
-- 🧪 Fuzz harness implemented; CI integration in progress
+- 🧪 Fuzz harness implemented; CI runs smoke fuzzing on every qualifying push/PR
 - 🔑 SHA-256 checksum verification for canonical release ZIP artifacts
 
 ### REST API security and operational limits (v1, implemented)

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,7 @@ all-features = true
 
 [advisories]
 version = 2
+db-urls = ["https://github.com/RustSec/advisory-db"]
 yanked = "deny"
 ignore = [
   # transitive via trippy-tui/maxminddb; no compatible update available while pinned to trippy 0.13.x


### PR DESCRIPTION
### Motivation

- Enforce supply-chain security gates in CI so pushes/PRs fail on known Rust advisories before merges.
- Catch regressions from fuzz harnesses early by running bounded fuzz smoke tests on every qualifying push/PR.
- Keep fuzzing and audit tooling CI-only and timeboxed to avoid long-running campaigns while still surfacing crashes.

### Description

- Add a new `security-audit` job to `.github/workflows/ci.yml` that runs on `ubuntu-latest` and depends on `pre-commit`.
- The job installs the Rust toolchain and `cargo-audit` (via `taiki-e/install-action`) and runs `cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked`.
- The job installs `cargo-fuzz`, runs `cargo fuzz build` for targets in `fuzz/`, and executes per-target bounded smoke runs using `timeout` with logic that tolerates timeouts but fails on non-timeout crashes.
- Update `README.md` to add a Security Audit badge and adjust the security wording, add a `Security & Fuzzing` section to `DEVELOPMENT.md` with local commands, and extend `deny.toml` to reference the RustSec advisory DB (`db-urls`).

### Testing

- Ran `cargo fmt --all -- --check` locally and it completed successfully.
- Ran `cargo test --all` locally and all tests passed.
- CI job behavior for `cargo-audit` and `cargo-fuzz` will be exercised on pushes/PRs (the workflow was added and smoke-run logic was validated in the repo layout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc7b9a97c8330a3fb7630cf1a5847)