### PR TITLE
ci: add security audit and fuzz smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,44 @@ jobs:
       - name: Smoke test container entrypoint
         run: docker run --rm windows-mtr:ci-amd64 --help
 
+  security-audit:
+    name: Security audit + fuzz smoke
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@6eb4471beed212309063862e6f5284ca3da3b01d # cargo-audit
+
+      - name: Run cargo audit (deny warnings, unmaintained, unsound, yanked)
+        run: cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Build fuzz targets
+        working-directory: fuzz
+        run: cargo fuzz build
+
+      - name: Run fuzz smoke (short timed run; fail on crash)
+        working-directory: fuzz
+        shell: bash
+        run: |
+          timeout 30s cargo fuzz run fuzz_passthrough_flags -- -max_total_time=20
+          status=$?
+          if [ $status -eq 124 ]; then
+            echo "Fuzz run timed out after 30s (expected for smoke mode)."
+            exit 0
+          fi
+          exit $status
+
   # New job to build binaries during pull requests for testing
   build-pr-binaries:
     name: Build PR Binaries

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,6 +92,18 @@ If you are working in a restricted environment and cannot install it, you can ex
 SKIP=hadolint pre-commit run --all-files
 ```
 
+## Security & Fuzzing
+
+- `cargo audit` runs in CI and fails the build on vulnerabilities (`--deny warnings --deny unmaintained --deny unsound --deny yanked`).
+- `cargo fuzz` runs a short smoke harness in CI to catch regressions/crashes early.
+- Fuzz targets live under `fuzz/`.
+- Local equivalents:
+
+```bash
+cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
+cd fuzz && cargo fuzz run fuzz_passthrough_flags -- -max_total_time=20
+```
+
 ## Project Layout
 
 - `src/` — core application code

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
   <p align="center">
     <a href="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml/badge.svg"></a>
+    <a href="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml"><img alt="Security Audit" src="https://github.com/benjisho/windows-mtr/actions/workflows/ci.yml/badge.svg?event=push&job=security-audit"></a>
     <a href="https://github.com/benjisho/windows-mtr/actions/workflows/release.yml"><img alt="Release" src="https://github.com/benjisho/windows-mtr/actions/workflows/release.yml/badge.svg?branch=master"></a>
     <a href="https://github.com/benjisho/windows-mtr/actions/workflows/security.yml"><img alt="Security" src="https://github.com/benjisho/windows-mtr/actions/workflows/security.yml/badge.svg"></a>
     <a href="https://github.com/benjisho/windows-mtr/releases"><img alt="Version" src="https://img.shields.io/github/v/release/benjisho/windows-mtr?color=blue&label=Version"></a>
@@ -93,7 +94,7 @@ Windows MTR is built with enterprise-level security practices:
 
 - 🛡️ Regular security audits with automated scanning
 - 🔒 All dependencies vetted for vulnerabilities
-- 🧪 Fuzz harness implemented; CI integration in progress
+- 🧪 Fuzz harness implemented; short regression smoke run enforced in CI
 - 🔑 SHA-256 checksum verification for canonical release ZIP artifacts
 
 ### REST API security and operational limits (v1, implemented)

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ all-features = true
 [advisories]
 version = 2
 yanked = "deny"
+# cargo-audit is enforced in CI with strict deny flags. Keep temporary ignores
+# explicit and documented until upstream dependency upgrades are available.
 ignore = [
   # transitive via trippy-tui/maxminddb; no compatible update available while pinned to trippy 0.13.x
   "RUSTSEC-2025-0132",


### PR DESCRIPTION
### Motivation

- Harden CI to automatically block known supply-chain issues and fuzz regressions per the Security Hardening Gates design for issue #183.  
- Provide a minimal, safe gate that runs `cargo-audit` and a short `cargo-fuzz` smoke run on Linux runners so PRs/pushes fail fast on advisories or crashes.  
- Preserve runtime/binary behavior by keeping tools CI-only and avoid broad repo refactors.  

### Description

- Added a new `security-audit` job in `.github/workflows/ci.yml` that sets up Rust, installs `cargo-audit`, runs `cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked`, installs `cargo-fuzz`, builds fuzz targets, and executes a short timed fuzz smoke run that treats timeouts as expected but fails on non-timeout crashes.  
- Updated `README.md` to add a security-audit badge and to note that a fuzz smoke run is enforced in CI.  
- Added a **Security & Fuzzing** section to `DEVELOPMENT.md` documenting CI behavior and local reproduction commands (`cargo audit` and example `cargo fuzz` invocation).  
- Clarified `deny.toml` with a short advisory note documenting the strict CI audit posture and the expectation that temporary ignores remain explicit and justified.  

### Testing

- Attempted workflow lint: ran `actionlint .github/workflows/ci.yml` in the environment but it failed because `actionlint` is not installed (`command not found`).  
- No additional automated tests were executed in this execution environment; CI jobs will run the new `security-audit` job on push/PR where full results (cargo-audit and fuzz outcomes) will be visible in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc7b9a97c8330a3fb7630cf1a5847)