### PR TITLE
ci: add security-audit job (cargo-audit + cargo-fuzz smoke) and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'deny.toml'
+      - 'fuzz/**'
+      - 'README.md'
+      - 'DEVELOPMENT.md'
       - 'src/**'
       - 'tests/**'
       - 'xtask/**'
@@ -29,6 +33,10 @@ on:
     paths:
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'deny.toml'
+      - 'fuzz/**'
+      - 'README.md'
+      - 'DEVELOPMENT.md'
       - 'src/**'
       - 'tests/**'
       - 'xtask/**'
@@ -681,3 +689,42 @@ jobs:
         shell: pwsh
         run: |
           "GitHub-hosted windows-latest runners cannot be interactively elevated; elevated probe smoke is provided via the optional self-hosted 'elevated' lane." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
+
+  security-audit:
+    name: Security audit + fuzz smoke
+    runs-on: ubuntu-latest
+    needs: pre-commit
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Build fuzz targets
+        run: cargo fuzz build --fuzz-dir fuzz
+
+      - name: Run fuzz smoke target (short CI run)
+        shell: bash
+        run: |
+          set -euo pipefail
+          target=$(cargo fuzz list --fuzz-dir fuzz | head -n 1)
+          if [ -z "$target" ]; then
+            echo "No fuzz targets found under fuzz/"
+            exit 1
+          fi
+
+          timeout --preserve-status 30s cargo fuzz run "$target" --fuzz-dir fuzz -- -max_total_time=20

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,6 +92,18 @@ If you are working in a restricted environment and cannot install it, you can ex
 SKIP=hadolint pre-commit run --all-files
 ```
 
+## Security & Fuzzing
+
+- `cargo audit` runs in CI and fails builds on known vulnerabilities/advisories.
+- `cargo fuzz` builds all harnesses in `fuzz/` and runs a short smoke target on every PR/push.
+- Keep local checks aligned with CI by running:
+
+```bash
+cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
+cargo fuzz build --fuzz-dir fuzz
+cargo fuzz run <target> --fuzz-dir fuzz -- -max_total_time=20
+```
+
 ## Project Layout
 
 - `src/` — core application code

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Windows MTR is built with enterprise-level security practices:
 
 - 🛡️ Regular security audits with automated scanning
 - 🔒 All dependencies vetted for vulnerabilities
-- 🧪 Fuzz harness implemented; CI integration in progress
+- 🧪 Fuzz harness implemented; CI enforces short regression smoke runs on each push/PR
 - 🔑 SHA-256 checksum verification for canonical release ZIP artifacts
 
 ### REST API security and operational limits (v1, implemented)


### PR DESCRIPTION
### Motivation
- Add supply-chain security and automated fuzz regression gating so pushes/PRs fail on known advisories or fuzz crashes.
- Ensure security and fuzzing checks run predictably on Linux runners and are discoverable/maintained via repository documentation.

### Description
- Add a `security-audit` job in `.github/workflows/ci.yml` that installs `cargo-audit`, runs `cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked`, installs `cargo-fuzz`, builds fuzz targets, and runs a time-boxed smoke run of the first discovered fuzz target.  
- Extend CI path filters for `push` and `pull_request` to include `deny.toml`, `fuzz/**`, `README.md`, and `DEVELOPMENT.md` so security/doc changes trigger the workflow.  
- Add a `Security & Fuzzing` section to `DEVELOPMENT.md` documenting the CI mirrors and local commands (`cargo audit` and `cargo fuzz`) to keep local checks aligned with CI.  
- Update `README.md` security messaging to reflect that short fuzz regression smoke runs are now enforced on each push/PR. 

### Testing
- Ran `cargo fmt --all -- --check` locally and it completed successfully.  
- Ran `cargo test --all` locally and the full test suite completed successfully (unit and integration tests passed).  
- The CI workflow additions were exercised via local edits and verified to be present in `.github/workflows/ci.yml` (job and path filters added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc7b9a97c8330a3fb7630cf1a5847)