### PR TITLE
ci: add cargo-audit and cargo-fuzz regression gate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,58 @@ jobs:
           $env:SMOKE_ARGS = "-n -r -c 1 127.0.0.1"
           cargo test --test privilege_probe_smoke -- --exact privilege_probe_smoke --nocapture
 
+
+  security-audit:
+    name: Security audit + fuzz regression gate
+    runs-on: ubuntu-latest
+    needs: pre-commit
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust (stable)
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Build fuzz targets
+        run: cargo fuzz build --fuzz-dir fuzz
+
+      - name: Run fuzz targets (short regression lane)
+        shell: bash
+        run: |
+          set -euo pipefail
+          targets=$(cargo fuzz list --fuzz-dir fuzz)
+          if [ -z "$targets" ]; then
+            echo "No fuzz targets found under fuzz/." >&2
+            exit 1
+          fi
+
+          while IFS= read -r target; do
+            [ -z "$target" ] && continue
+            echo "Running fuzz target: $target"
+            timeout --preserve-status 30s cargo fuzz run "$target" --fuzz-dir fuzz -- -max_total_time=20
+            status=$?
+            if [ "$status" -eq 124 ]; then
+              echo "Target $target reached CI timeout as expected; continuing."
+              continue
+            fi
+            if [ "$status" -ne 0 ]; then
+              echo "Target $target failed with status $status" >&2
+              exit "$status"
+            fi
+          done <<< "$targets"
+
   privilege-probe-smoke-windows-elevated-note:
     name: Privilege probe smoke (windows, elevated lane note)
     runs-on: windows-latest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -124,3 +124,17 @@ SKIP=hadolint pre-commit run --all-files
 - [Installation Guide](docs/INSTALLATION.md)
 - [Usage Guide](docs/USAGE.md)
 - [API Reference](docs/API.md)
+
+
+## Security & Fuzzing
+
+- `cargo audit` runs in CI on every push/PR and fails on known vulnerability advisories.
+- `cargo fuzz` builds every harness and runs a short, crash-detection regression lane in CI.
+- Full fuzz campaigns are intended for longer manual or scheduled runs.
+- Local commands:
+
+```bash
+cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked
+cargo fuzz build --fuzz-dir fuzz
+cargo fuzz run <target> --fuzz-dir fuzz
+```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Windows MTR is built with enterprise-level security practices:
 
 - 🛡️ Regular security audits with automated scanning
 - 🔒 All dependencies vetted for vulnerabilities
-- 🧪 Fuzz harness implemented; CI integration in progress
+- 🧪 Fuzz harness implemented with CI regression gating
 - 🔑 SHA-256 checksum verification for canonical release ZIP artifacts
 
 ### REST API security and operational limits (v1, implemented)

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,7 @@
 all-features = true
 
 [advisories]
+# NOTE: RustSec ignores are temporary and should be revisited regularly.
 version = 2
 yanked = "deny"
 ignore = [


### PR DESCRIPTION
### Motivation
- Add automated supply-chain auditing and short fuzz regression runs to the CI pipeline so PRs fail on known advisories or fuzz-detected crashes.
- Keep the changes minimal and CI-only so no runtime dependencies are introduced into the shipped binary.

### Description
- Added a new `security-audit` job to `.github/workflows/ci.yml` that runs on `ubuntu-latest`, installs `cargo-audit` and `cargo-fuzz`, runs `cargo audit --deny warnings --deny unmaintained --deny unsound --deny yanked`, builds fuzz targets with `cargo fuzz build`, and runs each fuzz target under a short timeout-based regression lane (timeouts treated as expected while non-zero non-timeout exits fail the job). 
- The fuzz step enumerates targets via `cargo fuzz list --fuzz-dir fuzz` and uses `timeout` to bound CI time; exit status `124` is considered a timeout and is continued while other non-zero statuses cause job failure. 
- Updated `README.md` security wording to reflect that fuzzing has CI regression gating and added a `Security & Fuzzing` section to `DEVELOPMENT.md` documenting CI behavior and local commands (`cargo audit`, `cargo fuzz build`, `cargo fuzz run`).
- Touched `deny.toml` to add a developer note reminding maintainers to revisit RustSec ignores regularly; no dependency changes to `Cargo.toml` or application runtime were made.

### Testing
- Ran `cargo fmt --all -- --check` locally and it succeeded. 
- CI changes are designed to run `cargo audit` and `cargo fuzz` on GitHub Actions for each push/PR; their behavior will be validated by the CI runs (not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc7b9a97c8330a3fb7630cf1a5847)