### PR TITLE
docs: document REST API envelope/headers and update roadmap priorities

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,6 +5,7 @@ Windows MTR is primarily a CLI application. This document defines its operationa
 1. Command-line interface (flags/options)
 2. Exit behavior
 3. Structured report output (JSON)
+4. REST API response envelope and operational headers
 
 ## CLI Interface
 
@@ -52,6 +53,23 @@ Consumer best practices:
 - Treat unknown fields as forward-compatible additions.
 - Avoid strict ordering assumptions.
 - Validate required fields in your own schema.
+
+
+## REST API Envelope and Headers
+
+For `mtr --api`, consumers should rely on the versioned response envelope and standard operational headers.
+
+Current baseline:
+
+- Response body includes `meta.schema_version` (currently `v1`) for compatibility checks.
+- Rate limiting is enforced server-side; expose and document rate-limit headers when enabled for client-side throttling (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`).
+- Return a request correlation header (`X-Request-ID` or equivalent) so clients can map failures to server logs.
+
+Client guidance:
+
+- Do not hard-fail on unknown envelope fields.
+- Prefer schema-version checks over ad-hoc field detection.
+- On `429`, back off using returned header values when present.
 
 ## Compatibility Notes
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,9 @@ For release-by-release details, see the [changelog](../CHANGELOG.md).
 | SNMP Integration | 📅 Planned | H2 2026 |
 | Dashboard UI (tabs, hop table, charts) | 🚧 In Progress (experimental preview via `--ui dashboard`, with deprecated alias `--ui native`) | H2 2026 |
 | ETW + Windows observability integrations | 🛣️ Roadmap | H2 2026 |
-| Versioned JSON schema + CSV export | 🛣️ Roadmap | H2 2026 |
+| Versioned JSON schema for automation outputs | 🚧 In Progress (`meta.schema_version` shipped for REST; CLI JSON contract version field pending) | H2 2026 |
+| REST API operational headers (`X-Request-ID`, standard rate-limit headers) | 📅 Planned | H2 2026 |
+| CSV export for report automation | 🛣️ Roadmap (optional convenience) | H2 2026 |
 | Security hardening gates (cargo-audit + fuzz harness in CI) | 🚧 In Progress (cargo-audit live, fuzz harness pending) | H2 2026 |
 | Cross-platform probe parity/privilege smoke tests | ✅ Released (CI `Probe parity (windows-latest\|ubuntu-latest)` + privilege smoke lanes: `Privilege probe smoke (ubuntu-latest\|windows-latest, non-elevated)`, `Privilege probe smoke (ubuntu-latest, elevated)`, and optional `Privilege probe smoke (windows, elevated self-hosted)`; coverage includes non-elevated failures on Windows/Ubuntu and elevated success on Ubuntu + Windows self-hosted; constraint: elevated Windows lane requires self-hosted runner because GitHub-hosted `windows-latest` cannot be interactively elevated.) | H2 2026 |
 | GitHub Actions hardening (pin workflow actions by commit SHA) | ✅ Released | v1.2.x |


### PR DESCRIPTION
### Motivation
- Clarify REST API expectations and prioritization of outstanding automation features by recording the response envelope, operational headers, and separate roadmap items so integrators can reliably consume `mtr --api` and track upcoming work.

### Description
- Added a `REST API Envelope and Headers` section to `docs/API.md` that documents `meta.schema_version`, recommends returning a request correlation header (e.g. `X-Request-ID`), and documents standard rate-limit response headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`).
- Updated `docs/ROADMAP.md` to split and clarify statuses for versioned JSON schema, REST API operational headers, and CSV export as distinct tracked items.

### Testing
- Ran `cargo test --all`, all test suites completed successfully (unit/integration API tests passed); this change is documentation-only and does not modify runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08801595108330b11f17e701e2132d)