### PR TITLE
Add Request-ID and Rate-Limit headers to REST API responses

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -60,6 +60,8 @@ When running in REST API mode (`--api`), probe creation endpoints emit rate-limi
 - `X-RateLimit-Limit`: maximum requests allowed in the active window.
 - `X-RateLimit-Remaining`: requests left in the active window.
 - `X-RateLimit-Reset`: **seconds until** the current window resets (not an epoch timestamp).
+- `RateLimit-Limit`: standards-aligned companion header carrying the same limit value.
+- `RateLimit-Remaining`: standards-aligned companion header carrying the same remaining value.
 - `RateLimit-Reset`: standards-aligned companion header carrying the same seconds-until-reset value.
 
 All REST responses also include:

--- a/docs/API.md
+++ b/docs/API.md
@@ -53,6 +53,19 @@ Consumer best practices:
 - Avoid strict ordering assumptions.
 - Validate required fields in your own schema.
 
+## REST API Response Headers
+
+When running in REST API mode (`--api`), probe creation endpoints emit rate-limit metadata for both success responses and throttled responses (`429 Too Many Requests`):
+
+- `X-RateLimit-Limit`: maximum requests allowed in the active window.
+- `X-RateLimit-Remaining`: requests left in the active window.
+- `X-RateLimit-Reset`: **seconds until** the current window resets (not an epoch timestamp).
+- `RateLimit-Reset`: standards-aligned companion header carrying the same seconds-until-reset value.
+
+All REST responses also include:
+
+- `X-Request-ID`: per-request correlation identifier for logs and troubleshooting.
+
 ## Compatibility Notes
 
 - CLI compatibility with Linux `mtr` is a goal, but not every flag is identical.

--- a/src/service/rest_api.rs
+++ b/src/service/rest_api.rs
@@ -408,6 +408,13 @@ pub struct FixedWindowRateLimiter {
     count: usize,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimitSnapshot {
+    pub limit: usize,
+    pub remaining: usize,
+    pub reset_after: Duration,
+}
+
 impl FixedWindowRateLimiter {
     pub fn new(
         max_requests: usize,
@@ -448,6 +455,18 @@ impl FixedWindowRateLimiter {
 
         self.count += 1;
         Ok(())
+    }
+
+    pub fn snapshot(&self, now: Instant) -> RateLimitSnapshot {
+        let elapsed = now.duration_since(self.window_started_at);
+        let reset_after = self.window.saturating_sub(elapsed);
+        let remaining = self.max_requests.saturating_sub(self.count);
+
+        RateLimitSnapshot {
+            limit: self.max_requests,
+            remaining,
+            reset_after,
+        }
     }
 }
 

--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -38,6 +38,8 @@ const REQUEST_ID_HEADER: &str = "X-Request-ID";
 const RATE_LIMIT_LIMIT_HEADER: &str = "X-RateLimit-Limit";
 const RATE_LIMIT_REMAINING_HEADER: &str = "X-RateLimit-Remaining";
 const RATE_LIMIT_RESET_HEADER: &str = "X-RateLimit-Reset";
+const RATE_LIMIT_LIMIT_STANDARD_HEADER: &str = "RateLimit-Limit";
+const RATE_LIMIT_REMAINING_STANDARD_HEADER: &str = "RateLimit-Remaining";
 const RATE_LIMIT_RESET_STANDARD_HEADER: &str = "RateLimit-Reset";
 
 type ApiResult<T> = Result<T, ApiError>;
@@ -179,7 +181,8 @@ pub struct RestServerState {
     pub concurrency_gate: Arc<ProbeConcurrencyGate>,
     probe_rate_limiter: Arc<Mutex<FixedWindowRateLimiter>>,
     store: Arc<Mutex<ProbeStore>>,
-    next_id: Arc<AtomicU64>,
+    next_job_id: Arc<AtomicU64>,
+    next_request_id: Arc<AtomicU64>,
     probe_runner_path: Arc<PathBuf>,
 }
 
@@ -210,14 +213,20 @@ impl RestServerState {
                 max_completed_jobs,
                 completed_job_ttl,
             })),
-            next_id: Arc::new(AtomicU64::new(1)),
+            next_job_id: Arc::new(AtomicU64::new(1)),
+            next_request_id: Arc::new(AtomicU64::new(1)),
             probe_runner_path: Arc::new(probe_runner_path),
         })
     }
 
     fn next_job_id(&self) -> String {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let id = self.next_job_id.fetch_add(1, Ordering::Relaxed);
         format!("probe-{id}")
+    }
+
+    fn next_request_id(&self) -> String {
+        let id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
+        format!("req-{id}")
     }
 }
 
@@ -246,7 +255,7 @@ async fn attach_request_id_response_header(
     request: Request,
     next: Next,
 ) -> axum::response::Response {
-    let request_id = format!("req-{}", state.next_id.fetch_add(1, Ordering::Relaxed));
+    let request_id = state.next_request_id();
     let mut response = next.run(request).await;
     if let Ok(value) = HeaderValue::from_str(&request_id) {
         response.headers_mut().insert(REQUEST_ID_HEADER, value);
@@ -302,7 +311,17 @@ fn attach_rate_limit_headers(
             .map_err(|_| internal_error_response("invalid rate limit header value"))?,
     );
     response.headers_mut().insert(
+        RATE_LIMIT_LIMIT_STANDARD_HEADER,
+        HeaderValue::from_str(&snapshot.limit.to_string())
+            .map_err(|_| internal_error_response("invalid rate limit header value"))?,
+    );
+    response.headers_mut().insert(
         RATE_LIMIT_REMAINING_HEADER,
+        HeaderValue::from_str(&snapshot.remaining.to_string())
+            .map_err(|_| internal_error_response("invalid rate limit header value"))?,
+    );
+    response.headers_mut().insert(
+        RATE_LIMIT_REMAINING_STANDARD_HEADER,
         HeaderValue::from_str(&snapshot.remaining.to_string())
             .map_err(|_| internal_error_response("invalid rate limit header value"))?,
     );

--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -10,6 +10,7 @@ use axum::body::{Body, to_bytes};
 use axum::extract::{ConnectInfo, Path, Request, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::{Next, from_fn_with_state};
+use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use subtle::ConstantTimeEq;
@@ -37,6 +38,7 @@ const REQUEST_ID_HEADER: &str = "X-Request-ID";
 const RATE_LIMIT_LIMIT_HEADER: &str = "X-RateLimit-Limit";
 const RATE_LIMIT_REMAINING_HEADER: &str = "X-RateLimit-Remaining";
 const RATE_LIMIT_RESET_HEADER: &str = "X-RateLimit-Reset";
+const RATE_LIMIT_RESET_STANDARD_HEADER: &str = "RateLimit-Reset";
 
 type ApiResult<T> = Result<T, ApiError>;
 
@@ -257,16 +259,21 @@ async fn enforce_probe_request_guards(
     request: Request,
     next: Next,
 ) -> ApiResult<axum::response::Response> {
-    let snapshot = {
+    let (snapshot, allow_result) = {
         let mut limiter = state
             .probe_rate_limiter
             .lock()
             .map_err(|_| internal_error_response("failed to lock probe rate limiter"))?;
-        limiter
-            .allow(Instant::now())
-            .map_err(validation_error_response)?;
-        limiter.snapshot(Instant::now())
+        let now = Instant::now();
+        let allow_result = limiter.allow(now);
+        let snapshot = limiter.snapshot(now);
+        (snapshot, allow_result)
     };
+    if let Err(error) = allow_result {
+        let mut response = validation_error_response(error).into_response();
+        attach_rate_limit_headers(&mut response, snapshot)?;
+        return Ok(response);
+    }
 
     let (parts, body) = request.into_parts();
     let payload = to_bytes(body, state.config.max_payload_bytes + 1)
@@ -281,6 +288,14 @@ async fn enforce_probe_request_guards(
 
     let request = Request::from_parts(parts, Body::from(payload));
     let mut response = next.run(request).await;
+    attach_rate_limit_headers(&mut response, snapshot)?;
+    Ok(response)
+}
+
+fn attach_rate_limit_headers(
+    response: &mut axum::response::Response,
+    snapshot: crate::service::rest_api::RateLimitSnapshot,
+) -> ApiResult<()> {
     response.headers_mut().insert(
         RATE_LIMIT_LIMIT_HEADER,
         HeaderValue::from_str(&snapshot.limit.to_string())
@@ -291,12 +306,16 @@ async fn enforce_probe_request_guards(
         HeaderValue::from_str(&snapshot.remaining.to_string())
             .map_err(|_| internal_error_response("invalid rate limit header value"))?,
     );
-    response.headers_mut().insert(
-        RATE_LIMIT_RESET_HEADER,
-        HeaderValue::from_str(&snapshot.reset_after.as_secs().to_string())
-            .map_err(|_| internal_error_response("invalid rate limit header value"))?,
-    );
-    Ok(response)
+    let reset_seconds = snapshot.reset_after.as_secs();
+    let reset_value = HeaderValue::from_str(&reset_seconds.to_string())
+        .map_err(|_| internal_error_response("invalid rate limit header value"))?;
+    response
+        .headers_mut()
+        .insert(RATE_LIMIT_RESET_HEADER, reset_value.clone());
+    response
+        .headers_mut()
+        .insert(RATE_LIMIT_RESET_STANDARD_HEADER, reset_value);
+    Ok(())
 }
 
 pub async fn run_rest_api_server(config: RestApiConfig) -> anyhow::Result<()> {

--- a/src/service/rest_server.rs
+++ b/src/service/rest_server.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use anyhow::{Context, anyhow};
 use axum::body::{Body, to_bytes};
 use axum::extract::{ConnectInfo, Path, Request, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::{Next, from_fn_with_state};
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -33,6 +33,10 @@ use crate::service::{
 
 const API_KEY_HEADER: &str = "X-API-Key";
 const EMBEDDED_TRIPPY_ENV: &str = "WINDOWS_MTR_EMBEDDED_TRIPPY";
+const REQUEST_ID_HEADER: &str = "X-Request-ID";
+const RATE_LIMIT_LIMIT_HEADER: &str = "X-RateLimit-Limit";
+const RATE_LIMIT_REMAINING_HEADER: &str = "X-RateLimit-Remaining";
+const RATE_LIMIT_RESET_HEADER: &str = "X-RateLimit-Reset";
 
 type ApiResult<T> = Result<T, ApiError>;
 
@@ -228,7 +232,24 @@ pub fn build_router(state: RestServerState) -> Router {
             )),
         )
         .route("/api/v1/probes/{id}", get(get_probe))
+        .layer(from_fn_with_state(
+            state.clone(),
+            attach_request_id_response_header,
+        ))
         .with_state(state)
+}
+
+async fn attach_request_id_response_header(
+    State(state): State<RestServerState>,
+    request: Request,
+    next: Next,
+) -> axum::response::Response {
+    let request_id = format!("req-{}", state.next_id.fetch_add(1, Ordering::Relaxed));
+    let mut response = next.run(request).await;
+    if let Ok(value) = HeaderValue::from_str(&request_id) {
+        response.headers_mut().insert(REQUEST_ID_HEADER, value);
+    }
+    response
 }
 
 async fn enforce_probe_request_guards(
@@ -236,7 +257,7 @@ async fn enforce_probe_request_guards(
     request: Request,
     next: Next,
 ) -> ApiResult<axum::response::Response> {
-    {
+    let snapshot = {
         let mut limiter = state
             .probe_rate_limiter
             .lock()
@@ -244,7 +265,8 @@ async fn enforce_probe_request_guards(
         limiter
             .allow(Instant::now())
             .map_err(validation_error_response)?;
-    }
+        limiter.snapshot(Instant::now())
+    };
 
     let (parts, body) = request.into_parts();
     let payload = to_bytes(body, state.config.max_payload_bytes + 1)
@@ -258,7 +280,23 @@ async fn enforce_probe_request_guards(
     validate_payload_size(payload.len(), &state.config).map_err(validation_error_response)?;
 
     let request = Request::from_parts(parts, Body::from(payload));
-    Ok(next.run(request).await)
+    let mut response = next.run(request).await;
+    response.headers_mut().insert(
+        RATE_LIMIT_LIMIT_HEADER,
+        HeaderValue::from_str(&snapshot.limit.to_string())
+            .map_err(|_| internal_error_response("invalid rate limit header value"))?,
+    );
+    response.headers_mut().insert(
+        RATE_LIMIT_REMAINING_HEADER,
+        HeaderValue::from_str(&snapshot.remaining.to_string())
+            .map_err(|_| internal_error_response("invalid rate limit header value"))?,
+    );
+    response.headers_mut().insert(
+        RATE_LIMIT_RESET_HEADER,
+        HeaderValue::from_str(&snapshot.reset_after.as_secs().to_string())
+            .map_err(|_| internal_error_response("invalid rate limit header value"))?,
+    );
+    Ok(response)
 }
 
 pub async fn run_rest_api_server(config: RestApiConfig) -> anyhow::Result<()> {

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -116,6 +116,45 @@ async fn create_probe_payload(
     create_res.json().await.expect("json body expected")
 }
 
+#[tokio::test]
+async fn responses_include_request_id_and_rate_limit_headers() {
+    let (addr, shutdown) = spawn_server().await;
+    let client = build_http_client();
+
+    let health = client
+        .get(format!("http://{addr}/api/v1/health"))
+        .send()
+        .await
+        .expect("health request should succeed");
+    assert!(health.headers().get("X-Request-ID").is_some());
+
+    let create = client
+        .post(format!("http://{addr}/api/v1/probes"))
+        .json(&serde_json::json!({
+            "targets": ["127.0.0.1"],
+            "protocol": "icmp",
+            "count": 1
+        }))
+        .send()
+        .await
+        .expect("create request should succeed");
+
+    assert!(create.headers().get("X-Request-ID").is_some());
+    let limit = create
+        .headers()
+        .get("X-RateLimit-Limit")
+        .expect("rate limit limit header should exist")
+        .to_str()
+        .expect("header should be utf-8")
+        .parse::<usize>()
+        .expect("header should be numeric");
+    assert!(limit >= 1);
+    assert!(create.headers().get("X-RateLimit-Remaining").is_some());
+    assert!(create.headers().get("X-RateLimit-Reset").is_some());
+
+    let _ = shutdown.send(());
+}
+
 async fn create_probe(
     client: &reqwest::Client,
     addr: SocketAddr,

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -151,6 +151,7 @@ async fn responses_include_request_id_and_rate_limit_headers() {
     assert!(limit >= 1);
     assert!(create.headers().get("X-RateLimit-Remaining").is_some());
     assert!(create.headers().get("X-RateLimit-Reset").is_some());
+    assert!(create.headers().get("RateLimit-Reset").is_some());
 
     let _ = shutdown.send(());
 }
@@ -587,6 +588,20 @@ async fn create_probe_rejects_burst_traffic_with_429() {
         .await
         .expect("third create probe request should succeed");
     assert_eq!(third.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+
+    assert!(third.headers().get("X-RateLimit-Limit").is_some());
+    assert!(third.headers().get("X-RateLimit-Remaining").is_some());
+    assert!(third.headers().get("X-RateLimit-Reset").is_some());
+    assert!(third.headers().get("RateLimit-Reset").is_some());
+    let remaining = third
+        .headers()
+        .get("X-RateLimit-Remaining")
+        .expect("remaining header should exist")
+        .to_str()
+        .expect("header should be utf-8")
+        .parse::<usize>()
+        .expect("header should be numeric");
+    assert_eq!(remaining, 0);
 
     let body: serde_json::Value = third.json().await.expect("json body expected");
     assert_error_shape(&body, 429, "rate_limited");

--- a/tests/rest_server_http_tests.rs
+++ b/tests/rest_server_http_tests.rs
@@ -151,6 +151,8 @@ async fn responses_include_request_id_and_rate_limit_headers() {
     assert!(limit >= 1);
     assert!(create.headers().get("X-RateLimit-Remaining").is_some());
     assert!(create.headers().get("X-RateLimit-Reset").is_some());
+    assert!(create.headers().get("RateLimit-Limit").is_some());
+    assert!(create.headers().get("RateLimit-Remaining").is_some());
     assert!(create.headers().get("RateLimit-Reset").is_some());
 
     let _ = shutdown.send(());
@@ -592,6 +594,8 @@ async fn create_probe_rejects_burst_traffic_with_429() {
     assert!(third.headers().get("X-RateLimit-Limit").is_some());
     assert!(third.headers().get("X-RateLimit-Remaining").is_some());
     assert!(third.headers().get("X-RateLimit-Reset").is_some());
+    assert!(third.headers().get("RateLimit-Limit").is_some());
+    assert!(third.headers().get("RateLimit-Remaining").is_some());
     assert!(third.headers().get("RateLimit-Reset").is_some());
     let remaining = third
         .headers()


### PR DESCRIPTION
### Motivation
- Improve API observability and client guidance by returning a unique request correlation header and standard rate-limit headers. 
- Address high-priority audit findings recommending `X-Request-ID` and `X-RateLimit-*` visibility for troubleshooting and client throttling.

### Description
- Add a `RateLimitSnapshot` struct and `snapshot()` method to `FixedWindowRateLimiter` to expose `limit`, `remaining`, and `reset_after` values (`src/service/rest_api.rs`).
- Emit `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` on probe creation responses inside the probe guard middleware (`src/service/rest_server.rs`).
- Add global `X-Request-ID` injection via a lightweight middleware `attach_request_id_response_header` that assigns a per-process incrementing request id (`src/service/rest_server.rs`).
- Add an integration test `responses_include_request_id_and_rate_limit_headers` that verifies the new headers are present and parseable (`tests/rest_server_http_tests.rs`).

### Testing
- Ran formatting and lint checks with `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`, both succeeding. 
- Ran the full test suite with `cargo test --all`, and all tests (including the new header integration test) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08801595108330b11f17e701e2132d)