### PR TITLE
docs: add gap prioritization and scope decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Updated README/USAGE roadmap and examples to document the dashboard fallback UI and controls.
 - Improved the dashboard UI help footer to show elapsed "awaiting data" time and add a 15-second timeout troubleshooting prompt when hop snapshots never arrive.
+- Added explicit gap-prioritization guidance to document which validated audit gaps are near-term, optional, or intentionally scope-dependent.
 
 ## [1.1.3] - 2026-02-28
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Capability claims are validated against source code, tests, CI, documentation, a
 - [🛣️ Product Roadmap](docs/ROADMAP.md)
 - [📦 Distribution Plan](docs/distribution.md)
 - [✅ Capability Validation Matrix](docs/capability-validation.md)
+- [🎯 Gap Prioritization & Scope Decisions](docs/gap-prioritization.md)
 - [🧩 CLI/API Reference](docs/API.md)
 - [🧪 Probe parity matrix](docs/probe-parity.md)
 - [📑 Usage Examples](docs/USAGE.md)

--- a/docs/gap-prioritization.md
+++ b/docs/gap-prioritization.md
@@ -1,0 +1,40 @@
+# Gap Prioritization and Scope Decisions
+
+This document captures current prioritization decisions for commonly requested feature gaps so roadmap and implementation choices remain explicit and predictable.
+
+## High-priority (near-term)
+
+These items are considered high-value for API reliability, integration safety, and client compatibility:
+
+1. Return standard rate-limit response metadata for REST API requests (for example: limit/remaining/reset semantics).
+2. Return a stable request-correlation header (for example `X-Request-ID`) for traceability between clients and logs.
+3. Add a version marker to JSON output schemas to protect downstream parsers from breaking changes.
+4. Ensure probe timeout behavior is explicit and consistently enforced at the wrapper level.
+
+## Medium-priority (planned convenience)
+
+These items are useful but not required for baseline correctness:
+
+1. CSV export mode (JSON remains the canonical machine-readable format).
+2. Additional packaging channels where maintenance cost is justified (for example Chocolatey hardening from template to publish-ready).
+
+## Optional / scope-dependent
+
+These items are valid ideas but depend on product direction and user demand:
+
+1. OAuth2/JWT auth flows for enterprise API environments (API key and mTLS remain sufficient defaults for many deployments).
+2. Webhook callback delivery model in addition to poll-based APIs.
+3. SNMP integration (often better handled by dedicated network-management tooling).
+4. ETW provider instrumentation for advanced Windows observability.
+
+## Platform and distribution scope notes
+
+- Windows remains the primary supported target.
+- macOS CI/release and Homebrew distribution are roadmap-level initiatives and require explicit signing/notarization/release process design before enablement.
+- GitHub Releases ZIP remains the canonical binary distribution source.
+
+## UX policy
+
+- Default embedded interactive mode is the recommended primary experience.
+- Dashboard mode is a fallback path for environments where embedded TUI stability is insufficient.
+- Unsupported UI flags should fail with clear validation guidance.


### PR DESCRIPTION
### Motivation
- Formalize validated audit gaps and encode near-term vs optional scope decisions so contributors can prioritize reliability work (rate-limit headers, request IDs, JSON schema versioning, probe timeouts) and understand planned convenience/optional items.

### Description
- Add `docs/gap-prioritization.md` with prioritized gap triage, link it from `README.md`, and record the addition in `CHANGELOG.md` under Unreleased.

### Testing
- Ran `cargo fmt --all -- --check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08801595108330b11f17e701e2132d)