### PR TITLE
docs: clarify supported UI presets and dashboard fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ mtr 8.8.8.8
 mtr --ui dashboard 8.8.8.8
 ```
 
-`--ui enhanced` is currently unavailable with bundled Trippy 0.13.0. Use default mode (`mtr 8.8.8.8`) for the full embedded Trippy TUI.
+Use default mode (`mtr 8.8.8.8`) for the embedded Trippy TUI. `--ui dashboard` is an experimental fallback, and `--ui native` remains a deprecated compatibility alias.
 
 ### Report mode with DNS disabled (faster + script-friendly)
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,7 +34,7 @@ mtr [options] <hostname-or-ip>
 | `-n` | Disable reverse DNS rendering (show IP only) |
 | `-b, --show-asn` | Enable ASN lookup/rendering |
 | `-z` | DNS ASN lookup shortcut |
-| `--ui <default\|enhanced\|dashboard>` | Interactive UI preset (`enhanced` currently unavailable with bundled Trippy 0.13.0) |
+| `--ui <default\|dashboard>` | Interactive UI preset (`dashboard` is experimental fallback; `native` is deprecated alias) |
 
 ## Dashboard UI (experimental fallback)
 
@@ -69,11 +69,11 @@ For stable diagnostics, use report mode:
 .\mtr.exe -n -r -c 5 8.8.8.8
 ```
 
-## Enhanced UI options
+## Enhanced UI options (deprecated)
 
-`--ui enhanced` is currently unavailable with bundled Trippy 0.13.0. Running enhanced mode now returns a clear validation error that recommends default UI or dashboard fallback.
+`--ui enhanced` is intentionally not part of the supported interactive presets.
 
-Enhanced tuning flags are retained for forward compatibility but require future bundled Trippy support before they can be used again.
+Legacy enhanced tuning flags remain parser-visible only for compatibility and currently fail validation with guidance to use default UI or `--ui dashboard`.
 
 ## Timing & DNS Cache
 


### PR DESCRIPTION
### Motivation
- Reduce user confusion about interactive UI modes by clearly documenting the supported presets and marking legacy/experimental options appropriately.

### Description
- Update `USAGE.md` and `README.md` to list `--ui <default|dashboard>` (with `--ui native` as a deprecated alias), reword the Enhanced UI section to mark `--ui enhanced` as unsupported/deprecated while retaining legacy flags as parser-visible for compatibility, and clarify that `--ui dashboard` is an experimental fallback (files changed: `USAGE.md`, `README.md`).

### Testing
- Run `cargo test --all` and verified the full test suite completed successfully with no failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08801595108330b11f17e701e2132d)