### PR TITLE
docs: refresh ROADMAP priorities (promote exports & dashboard fallback; move SNMP/ETW to long-term)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,10 +26,11 @@ For release-by-release details, see the [changelog](../CHANGELOG.md).
 | CodeQL workflow for Rust | ✅ Released | v1.2.x |
 | Container publishing to GHCR + Docker Hub | ✅ Released | v1.2.x |
 | REST API (API key + mTLS auth, rate limiting, concurrency controls) | ✅ Released | v1.1.3 |
-| SNMP Integration | 📅 Planned | H2 2026 |
+| SNMP Integration (optional) | 🛣️ Long-term roadmap | 2027+ |
 | Dashboard UI (tabs, hop table, charts) | 🚧 In Progress (experimental preview via `--ui dashboard`, with deprecated alias `--ui native`) | H2 2026 |
-| ETW + Windows observability integrations | 🛣️ Roadmap | H2 2026 |
-| Versioned JSON schema + CSV export | 🛣️ Roadmap | H2 2026 |
+| Dashboard fallback UI improvements | 🚧 In Progress / Next | H2 2026 |
+| ETW + Windows observability integrations (optional) | 🛣️ Long-term roadmap | 2027+ |
+| Versioned JSON & CSV export | 🚧 In Progress / Next | H2 2026 |
 | Security hardening gates (cargo-deny + cargo-audit + fuzz smoke in CI) | ✅ Released | v1.2.x |
 | Advanced security hardening (long-running/scheduled fuzzing, advisory cleanup) | 🛣️ Roadmap | H2 2026 |
 | Cross-platform probe parity/privilege smoke tests | ✅ Released (CI `Probe parity (windows-latest\|ubuntu-latest)` + privilege smoke lanes: `Privilege probe smoke (ubuntu-latest\|windows-latest, non-elevated)`, `Privilege probe smoke (ubuntu-latest, elevated)`, and optional `Privilege probe smoke (windows, elevated self-hosted)`; coverage includes non-elevated failures on Windows/Ubuntu and elevated success on Ubuntu + Windows self-hosted; constraint: elevated Windows lane requires self-hosted runner because GitHub-hosted `windows-latest` cannot be interactively elevated.) | H2 2026 |


### PR DESCRIPTION
### Motivation
- Align the public roadmap with current priorities by marking security gating as released, surfacing dashboard fallback improvements and Versioned JSON/CSV export as near-term work, and de-emphasizing SNMP/ETW as optional/long-term items.

### Description
- Update `docs/ROADMAP.md` to make these changes: mark `SNMP Integration` as `SNMP Integration (optional)` with a `Long-term roadmap (2027+)` timeline, add a `Dashboard fallback UI improvements` row marked `🚧 In Progress / Next`, move `ETW + Windows observability integrations` to an `(optional)` long-term row, and promote `Versioned JSON & CSV export` to `🚧 In Progress / Next`.

### Testing
- No automated tests were run for this docs-only change; changes were validated by inspecting the updated file (`git diff -- docs/ROADMAP.md`) and repository CI will run linters/validation on push.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a118a3075ac8330a3a8fc8e944f214f)