### PR TITLE
fix: add a release package dry run for v1.2.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,17 +193,13 @@ jobs:
           provenance: true
           sbom: true
 
-  # Only run for tag pushes (real releases)
-  release:
-    name: Create Release
-    needs:
-      - build
-      - publish-package
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+  # Build and validate the canonical ZIP on tag pushes and manual dry runs.
+  package-smoke:
+    name: Package and Smoke Test
+    needs: build
     runs-on: windows-latest
-    # Add explicit permissions for creating releases
     permissions:
-      contents: write  # Required for creating releases and uploading assets
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -304,9 +300,24 @@ jobs:
           if-no-files-found: error
           compression-level: 9
 
-      # Create the GitHub release with only the official zip file
+  # Publish only a package that has passed the exact dry-run validation above.
+  release:
+    name: Create Release
+    needs:
+      - package-smoke
+      - publish-package
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download validated release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: windows-mtr-release
+          path: dist
+
       - name: Create GitHub Release
-        id: create_release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:
           files: |

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,13 +1,9 @@
-name: Windows Build and Release
+name: Windows Build
 
 on:
   # Manually triggered from GitHub UI
   workflow_dispatch:
 
-  # On release tag push
-  push:
-    tags:
-      - 'v*'
 
 permissions:
   contents: read
@@ -100,28 +96,3 @@ jobs:
             dist/mtr.exe
             dist/*.zip
             dist/SHA256SUMS
-
-  # Only run on tag push
-  release:
-    needs: build-windows
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write  # Required for creating releases and uploading assets
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      - name: Create GitHub Release
-        id: create_release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
-        with:
-          files: |
-            windows-binaries/windows-mtr.exe
-            windows-binaries/*.zip
-            windows-binaries/SHA256SUMS
-          draft: true
-          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.8] - 2026-07-18
+
 ### Added
 - Added an experimental dashboard preview mode via `--ui dashboard` (deprecated compatibility alias: `--ui native`) with tabs, hop table rendering, and live latency/loss charts.
+- Added a native Windows IPv4 ICMP backend for the default interactive UI, report, JSON, and dashboard modes, plus loopback end-to-end coverage.
 - Added --csv <PATH> CLI flag for CSV report export (mutually exclusive with --json/--json-pretty/-r/-w).
 - Added schema_version field ("1.0") to CLI JSON output (--json / --json-pretty).
 - Added packaged-binary smoke tests for release and PR ZIP artifacts, covering JSON, CSV, TCP, UDP, and REST API health paths.
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Updated README/USAGE roadmap and examples to document the dashboard fallback UI and controls.
 - Improved the dashboard UI help footer to show elapsed "awaiting data" time and add a 15-second timeout troubleshooting prompt when hop snapshots never arrive.
 - Packaging tasks now fail when a real Windows executable is missing; they no longer create placeholder artifacts.
+- Release workflow dispatches now build, package, validate, and smoke-test the canonical ZIP without publishing it.
 
 ## [1.1.3] - 2026-02-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-mtr"
-version = "1.1.3"
+version = "1.2.8"
 edition = "2024"
 authors = ["Benji Shohet <benjisho>"]
 description = "Windows-native clone of Linux mtr — cross-platform Rust CLI for ICMP/TCP/UDP traceroute & ping"


### PR DESCRIPTION
## Summary
- bump the package version and changelog to v1.2.8
- run canonical ZIP packaging, validation, and smoke tests on manual Release workflow dispatches without publishing
- make tag releases consume the already validated artifact
- retire the competing legacy tag-release workflow

## Why
The v1.2.7 release built successfully but the packaged JSON smoke test crashed in embedded Trippy before assets could be uploaded. The native Windows ICMP backend on master avoids that JSON path; this change lets us verify the full package before creating the v1.2.8 tag.

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all: completed suites passed; final test executable was blocked locally by Windows Application Control
- cargo test --test api_integration_tests api_cancellation_releases_concurrency_slot_for_follow_up_request -- --exact
- release binary: --version reports 1.2.8; native ICMP JSON loopback report succeeds
- release ZIP verification succeeds locally
- full release smoke script reaches the CSV probe; local session lacks Trippy network privileges for that and subsequent TCP/UDP probes

## Follow-up
After this PR merges, manually dispatch the Release workflow as the dry run. Tag v1.2.8 only after the Package and Smoke Test job passes.